### PR TITLE
Add context awareness RBAC permissions

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version of kubewarden-controller container image to be used
-appVersion: "v0.1.0"
+appVersion: "v0.1.3"

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
         - --deployments-namespace={{ .Release.Namespace }}
+        - --deployments-service-account-name={{ .Values.policyServer.serviceAccountName }}
         command:
         - /manager
         image: '{{ .Values.image.repository | default "ghcr.io/kubewarden/kubewarden-controller" }}:{{ .Values.image.tag | default .Chart.AppVersion }}'

--- a/charts/kubewarden-controller/templates/policy-server-rbac.yaml
+++ b/charts/kubewarden-controller/templates/policy-server-rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.policyServer.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubewarden-context-watcher
+rules:
+{{- range .Values.policyServer.permissions }}
+- apiGroups:
+  - {{ .apiGroup | quote }}
+  resources: {{ .resources | toJson }}
+  verbs:
+  - list
+  - watch
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubewarden-context-watcher
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.policyServer.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: kubewarden-context-watcher
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -15,10 +15,20 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
-
 # Policy Server settings
 policyServer:
   replicaCount: 1
   image:
     repository: ghcr.io/kubewarden/policy-server
     tag: "v0.1.2"
+  serviceAccountName: policy-server
+# All permissions are cluster-wide. Even namespaced resources are
+# granted access in all namespaces at this time.
+  permissions:
+  - apiGroup: ""
+    resources:
+    - namespaces
+    - services
+  - apiGroup: "networking.k8s.io"
+    resources:
+    - ingresses


### PR DESCRIPTION
Implements https://github.com/kubewarden/helm-charts/issues/4

The `policy-server` requires to list well known resources, so
context-aware policies can take decisions based on this information.

While this permissions, and what resources can be listed and watched
will be customizable in the future, right now is a fixed set of
resources:

- Namespaces
- Services
- Ingresses

This list is customizable by overriding the helm chart `values.yaml`.