### PR TITLE
Update the helm chart: enable rego support

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version of kubewarden-controller container image to be used
 appVersion: "v0.3.2"

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -20,7 +20,7 @@ policyServer:
   replicaCount: 1
   image:
     repository: ghcr.io/kubewarden/policy-server
-    tag: "v0.1.10"
+    tag: "v0.2.0"
   serviceAccountName: policy-server
 # All permissions are cluster-wide. Even namespaced resources are
 # granted access in all namespaces at this time.


### PR DESCRIPTION
Deploy the latest stable release of the policy-server container image.
This release allows to use Rego based policies too, like the ones created with Open Policy Agent and Gatekeeper.

Update policy-server image to v0.2.0.

Note well: this is still based on the old architecture.