### PR TITLE
Add webhook server, cert-manager support

### DIFF
--- a/charts/kubewarden-controller/README.md
+++ b/charts/kubewarden-controller/README.md
@@ -14,15 +14,20 @@ it is deployed.
 
 ## Installation
 
-The kubewarden-controller can be deployed using a helm chart:
+The kubewarden-controller can be deployed using a helm chart.
+To install the kubewarden-controller in an existing cluster, make sure you have
+[`cert-manager` installed](https://cert-manager.io/docs/installation/) and then
+install the kubewarden-controller.
 
-```shell
+For example:
+```console
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
 $ helm repo add kubewarden https://charts.kubewarden.io
 $ helm install --create-namespace -n kubewarden kubewarden-controller kubewarden/kubewarden-controller
 ```
 
-This will install kubewarden-controller on the Kubernetes cluster in the default
-configuration.
+This will install cert-manager, and kubewarden-controller on the Kubernetes
+cluster in the default configuration (which includes self-signed TLS certs).
 
 The default configuration values should be good enough for the
 majority of deployments, all the options are documented

--- a/charts/kubewarden-controller/README.md
+++ b/charts/kubewarden-controller/README.md
@@ -23,7 +23,7 @@ For example:
 ```console
 $ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
 $ helm repo add kubewarden https://charts.kubewarden.io
-$ helm install --create-namespace -n kubewarden kubewarden-controller kubewarden/kubewarden-controller
+$ helm install --wait --create-namespace -n kubewarden kubewarden-controller kubewarden/kubewarden-controller
 ```
 
 This will install cert-manager, and kubewarden-controller on the Kubernetes

--- a/charts/kubewarden-controller/README.md
+++ b/charts/kubewarden-controller/README.md
@@ -51,17 +51,21 @@ The following snippet defines a Kubewarden Policy based on the
 policy:
 
 ```yaml
-apiVersion: policies.kubewarden.io/v1alpha1
+---
+apiVersion: policies.kubewarden.io/v1alpha2
 kind: ClusterAdmissionPolicy
 metadata:
   name: privileged-pods
 spec:
-  module: registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.5
-  resources:
-  - pods
-  operations:
-  - CREATE
-  - UPDATE
+  policyServer: default
+  module: registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.9
+  rules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+      operations:
+        - CREATE
+        - UPDATE
   mutating: false
 ```
 

--- a/charts/kubewarden-controller/crds/clusteradmissionpolicies.yaml
+++ b/charts/kubewarden-controller/crds/clusteradmissionpolicies.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: clusteradmissionpolicies.policies.kubewarden.io
 spec:
   group: policies.kubewarden.io
@@ -15,364 +14,219 @@ spec:
     singular: clusteradmissionpolicy
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - description: Whether the policy is mutating
-          jsonPath: .spec.mutating
-          name: Mutating
-          type: boolean
-        - description: Whether the policy is active and receiving admission reviews
-          jsonPath: .status.policyActive
-          name: Active
-          type: boolean
-      name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: ClusterAdmissionPolicy is the Schema for the clusteradmissionpolicies
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy
-              properties:
-                failurePolicy:
-                  description: FailurePolicy defines how unrecognized errors and timeout
-                    errors from the policy are handled. Allowed values are "Ignore"
-                    or "Fail". * "Ignore" means that an error calling the webhook is
-                    ignored and the API   request is allowed to continue. * "Fail" means
-                    that an error calling the webhook causes the admission to   fail
-                    and the API request to be rejected. The default behaviour is "Fail"
-                  type: string
-                matchPolicy:
-                  description: "matchPolicy defines how the \"rules\" list is used to
-                  match incoming requests. Allowed values are \"Exact\" or \"Equivalent\".
-                  \n - Exact: match a request only if it exactly matches a specified
-                  rule. For example, if deployments can be modified via apps/v1, apps/v1beta1,
-                  and extensions/v1beta1, but \"rules\" only included `apiGroups:[\"apps\"],
-                  apiVersions:[\"v1\"], resources: [\"deployments\"]`, a request to
-                  apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
-                  \n - Equivalent: match a request if modifies a resource listed in
-                  rules, even via another API group or version. For example, if deployments
-                  can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1,
-                  and \"rules\" only included `apiGroups:[\"apps\"], apiVersions:[\"v1\"],
-                  resources: [\"deployments\"]`, a request to apps/v1beta1 or extensions/v1beta1
-                  would be converted to apps/v1 and sent to the webhook. \n Defaults
-                  to \"Equivalent\""
-                  type: string
-                module:
-                  description: Module is the location of the WASM module to be loaded.
-                    Can be a local file (file://), a remote file served by an HTTP server
-                    (http://, https://), or an artifact served by an OCI-compatible
-                    registry (registry://).
-                  type: string
-                mutating:
-                  description: Mutating indicates whether a policy has the ability to
-                    mutate incoming requests or not.
-                  type: boolean
-                namespaceSelector:
-                  description: "NamespaceSelector decides whether to run the webhook
-                  on an object based on whether the namespace for that object matches
-                  the selector. If the object itself is a namespace, the matching
-                  is performed on object.metadata.labels. If the object is another
-                  cluster scoped resource, it never skips the webhook. \n For example,
-                  to run the webhook on any objects whose namespace is not associated
-                  with \"runlevel\" of \"0\" or \"1\";  you will set the selector
-                  as follows: \"namespaceSelector\": {   \"matchExpressions\": [     {
-                  \      \"key\": \"runlevel\",       \"operator\": \"NotIn\",       \"values\":
-                  [         \"0\",         \"1\"       ]     }   ] } \n If instead
-                  you want to only run the webhook on any objects whose namespace
-                  is associated with the \"environment\" of \"prod\" or \"staging\";
-                  you will set the selector as follows: \"namespaceSelector\": {   \"matchExpressions\":
-                  [     {       \"key\": \"environment\",       \"operator\": \"In\",
-                  \      \"values\": [         \"prod\",         \"staging\"       ]
-                  \    }   ] } \n See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-                  for more examples of label selectors. \n Default to the empty LabelSelector,
-                  which matches everything."
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the key
-                          and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
+  - additionalPrinterColumns:
+    - description: Whether the policy is mutating
+      jsonPath: .spec.mutating
+      name: Mutating
+      type: boolean
+    - description: Status of the policy
+      jsonPath: .status.policyStatus
+      name: Status
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterAdmissionPolicy is the Schema for the clusteradmissionpolicies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy
+            properties:
+              failurePolicy:
+                description: FailurePolicy defines how unrecognized errors and timeout errors from the policy are handled. Allowed values are "Ignore" or "Fail". * "Ignore" means that an error calling the webhook is ignored and the API   request is allowed to continue. * "Fail" means that an error calling the webhook causes the admission to   fail and the API request to be rejected. The default behaviour is "Fail"
+                type: string
+              matchPolicy:
+                description: "matchPolicy defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" or \"Equivalent\". \n - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but \"rules\" only included `apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook. \n - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and \"rules\" only included `apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook. \n Defaults to \"Equivalent\""
+                type: string
+              module:
+                description: Module is the location of the WASM module to be loaded. Can be a local file (file://), a remote file served by an HTTP server (http://, https://), or an artifact served by an OCI-compatible registry (registry://).
+                type: string
+              mutating:
+                description: Mutating indicates whether a policy has the ability to mutate incoming requests or not.
+                type: boolean
+              namespaceSelector:
+                description: "NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook. \n For example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {   \"matchExpressions\": [     {       \"key\": \"runlevel\",       \"operator\": \"NotIn\",       \"values\": [         \"0\",         \"1\"       ]     }   ] } \n If instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {   \"matchExpressions\": [     {       \"key\": \"environment\",       \"operator\": \"In\",       \"values\": [         \"prod\",         \"staging\"       ]     }   ] } \n See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels for more examples of label selectors. \n Default to the empty LabelSelector, which matches everything."
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
                             type: string
-                          operator:
-                            description: operator represents a key's relationship to
-                              a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                          type: array
+                      required:
+                      - key
+                      - operator
                       type: object
-                  type: object
-                objectSelector:
-                  description: ObjectSelector decides whether to run the webhook based
-                    on if the object has matching labels. objectSelector is evaluated
-                    against both the oldObject and newObject that would be sent to the
-                    webhook, and is considered to match if either object matches the
-                    selector. A null object (oldObject in the case of create, or newObject
-                    in the case of delete) or an object that cannot have labels (like
-                    a DeploymentRollback or a PodProxyOptions object) is not considered
-                    to match. Use the object selector only if the webhook is opt-in,
-                    because end users may skip the admission webhook by setting the
-                    labels. Default to the empty LabelSelector, which matches everything.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the key
-                          and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              objectSelector:
+                description: ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
                             type: string
-                          operator:
-                            description: operator represents a key's relationship to
-                              a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                          type: array
+                      required:
+                      - key
+                      - operator
                       type: object
-                  type: object
-                policyServer:
-                  default: default
-                  description: PolicyServer identifies an existing PolicyServer resource.
-                  type: string
-                rules:
-                  description: Rules describes what operations on what resources/subresources
-                    the webhook cares about. The webhook cares about an operation if
-                    it matches _any_ Rule.
-                  items:
-                    description: RuleWithOperations is a tuple of Operations and Resources.
-                      It is recommended to make sure that all the tuple expansions are
-                      valid.
-                    properties:
-                      apiGroups:
-                        description: APIGroups is the API groups the resources belong
-                          to. '*' is all groups. If '*' is present, the length of the
-                          slice must be one. Required.
-                        items:
-                          type: string
-                        type: array
-                      apiVersions:
-                        description: APIVersions is the API versions the resources belong
-                          to. '*' is all versions. If '*' is present, the length of
-                          the slice must be one. Required.
-                        items:
-                          type: string
-                        type: array
-                      operations:
-                        description: Operations is the operations the admission hook
-                          cares about - CREATE, UPDATE, DELETE, CONNECT or * for all
-                          of those operations and any future admission operations that
-                          are added. If '*' is present, the length of the slice must
-                          be one. Required.
-                        items:
-                          type: string
-                        type: array
-                      resources:
-                        description: "Resources is a list of resources this rule applies
-                        to. \n For example: 'pods' means pods. 'pods/log' means the
-                        log subresource of pods. '*' means all resources, but not
-                        subresources. 'pods/*' means all subresources of pods. '*/scale'
-                        means all scale subresources. '*/*' means all resources and
-                        their subresources. \n If wildcard is present, the validation
-                        rule will ensure resources do not overlap with each other.
-                        \n Depending on the enclosing object, subresources might not
-                        be allowed. Required."
-                        items:
-                          type: string
-                        type: array
-                      scope:
-                        description: scope specifies the scope of this rule. Valid values
-                          are "Cluster", "Namespaced", and "*" "Cluster" means that
-                          only cluster-scoped resources will match this rule. Namespace
-                          API objects are cluster-scoped. "Namespaced" means that only
-                          namespaced resources will match this rule. "*" means that
-                          there are no scope restrictions. Subresources match the scope
-                          of their parent resource. Default is "*".
-                        type: string
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
-                  type: array
-                settings:
-                  description: 'Settings is a free-form object that contains the policy
-                  configuration values. x-kubernetes-embedded-resource: false'
+                type: object
+              policyServer:
+                default: default
+                description: PolicyServer identifies an existing PolicyServer resource.
+                type: string
+              rules:
+                description: Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
+                items:
+                  description: RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.
+                  properties:
+                    apiGroups:
+                      description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                      items:
+                        type: string
+                      type: array
+                    apiVersions:
+                      description: APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+                      items:
+                        type: string
+                      type: array
+                    operations:
+                      description: Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+                      items:
+                        type: string
+                      type: array
+                    resources:
+                      description: "Resources is a list of resources this rule applies to. \n For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources. \n If wildcard is present, the validation rule will ensure resources do not overlap with each other. \n Depending on the enclosing object, subresources might not be allowed. Required."
+                      items:
+                        type: string
+                      type: array
+                    scope:
+                      description: scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+                      type: string
                   type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                sideEffects:
-                  description: 'SideEffects states whether this webhook has side effects.
-                  Acceptable values are: None, NoneOnDryRun (webhooks created via
-                  v1beta1 may also specify Some or Unknown). Webhooks with side effects
-                  MUST implement a reconciliation system, since a request may be rejected
-                  by a future step in the admission change and the side effects therefore
-                  need to be undone. Requests with the dryRun attribute will be auto-rejected
-                  if they match a webhook with sideEffects == Unknown or Some.'
-                  type: string
-                timeoutSeconds:
-                  description: TimeoutSeconds specifies the timeout for this webhook.
-                    After the timeout passes, the webhook call will be ignored or the
-                    API call will fail based on the failure policy. The timeout value
-                    must be between 1 and 30 seconds. Default to 10 seconds.
-                  format: int32
-                  type: integer
-              required:
-                - mutating
-                - rules
-              type: object
-            status:
-              description: ClusterAdmissionPolicyStatus defines the observed state of
-                ClusterAdmissionPolicy
-              properties:
-                conditions:
-                  description: 'Conditions represent the observed conditions of the
-                  ClusterAdmissionPolicy resource.  Known .status.conditions.types
-                  are: "PolicyServerSecretReconciled", "PolicyServerConfigMapReconciled",
-                  "PolicyServerDeploymentReconciled", "PolicyServerServiceReconciled"
-                  and "PolicyServerWebhookRegistered"'
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition
-                          transitioned from one status to another. This should be when
-                          the underlying condition changed.  If that is not known, then
-                          using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: message is a human readable message indicating
-                          details about the transition. This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation
-                          that the condition was set based upon. For instance, if .metadata.generation
-                          is currently 12, but the .status.conditions[x].observedGeneration
-                          is 9, the condition is out of date with respect to the current
-                          state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: reason contains a programmatic identifier indicating
-                          the reason for the condition's last transition. Producers
-                          of specific condition types may define expected values and
-                          meanings for this field, and whether the values are considered
-                          a guaranteed API. The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                          --- Many .condition.type values are consistent across resources
-                          like Available, but because arbitrary conditions can be useful
-                          (see .node.status.conditions), the ability to deconflict is
-                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                policyActive:
-                  description: PolicyActive represents whether this AdmissionPolicy
-                    is active, such that the Kubernetes API server should be forwarding
-                    admission review objects to the policy
-                  type: boolean
-              required:
-                - conditions
-                - policyActive
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              settings:
+                description: 'Settings is a free-form object that contains the policy configuration values. x-kubernetes-embedded-resource: false'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              sideEffects:
+                description: 'SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.'
+                type: string
+              timeoutSeconds:
+                description: TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
+                format: int32
+                type: integer
+            required:
+            - mutating
+            - rules
+            type: object
+          status:
+            description: ClusterAdmissionPolicyStatus defines the observed state of ClusterAdmissionPolicy
+            properties:
+              conditions:
+                description: 'Conditions represent the observed conditions of the ClusterAdmissionPolicy resource.  Known .status.conditions.types are: "PolicyServerSecretReconciled", "PolicyServerConfigMapReconciled", "PolicyServerDeploymentReconciled", "PolicyServerServiceReconciled" and "ClusterAdmissionPolicyActive"'
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              policyStatus:
+                description: PolicyStatus represents whether this ClusterAdmissionPolicy is unscheduled, unschedulable, pending, or active.
+                enum:
+                - unscheduled
+                - unschedulable
+                - pending
+                - active
+                type: string
+            required:
+            - policyStatus
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/kubewarden-controller/crds/policyserver.yaml
+++ b/charts/kubewarden-controller/crds/policyserver.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: policyservers.policies.kubewarden.io
 spec:
   group: policies.kubewarden.io
@@ -16,239 +14,179 @@ spec:
     singular: policyserver
   scope: Cluster
   versions:
-    - name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: PolicyServer is the Schema for the policyservers API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: PolicyServerSpec defines the desired state of PolicyServer
-              properties:
-                annotations:
-                  additionalProperties:
-                    type: string
-                  description: 'Annotations is an unstructured key value map stored
-                  with a resource that may be set by external tools to store and retrieve
-                  arbitrary metadata. They are not queryable and should be preserved
-                  when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: PolicyServer is the Schema for the policyservers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyServerSpec defines the desired state of PolicyServer
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                type: object
+              env:
+                description: List of environment variables to set in the container. Cannot be updated.
+                items:
+                  description: EnvVar represents an environment variable present in a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes, optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
                   type: object
-                env:
-                  description: List of environment variables to set in the container.
-                    Cannot be updated.
-                  items:
-                    description: EnvVar represents an environment variable present in
-                      a Container.
-                    properties:
-                      name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
-                        type: string
-                      value:
-                        description: 'Variable references $(VAR_NAME) are expanded using
-                        the previous defined environment variables in the container
-                        and any service environment variables. If a variable cannot
-                        be resolved, the reference in the input string will be unchanged.
-                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                        $$(VAR_NAME). Escaped references will never be expanded, regardless
-                        of whether the variable exists or not. Defaults to "".'
-                        type: string
-                      valueFrom:
-                        description: Source for the environment variable's value. Cannot
-                          be used if value is not empty.
-                        properties:
-                          configMapKeyRef:
-                            description: Selects a key of a ConfigMap.
-                            properties:
-                              key:
-                                description: The key to select.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the ConfigMap or its key
-                                  must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                          fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
-                            properties:
-                              apiVersion:
-                                description: Version of the schema the FieldPath is
-                                  written in terms of, defaults to "v1".
-                                type: string
-                              fieldPath:
-                                description: Path of the field to select in the specified
-                                  API version.
-                                type: string
-                            required:
-                              - fieldPath
-                            type: object
-                          resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
-                            properties:
-                              containerName:
-                                description: 'Container name: required for volumes,
-                                optional for env vars'
-                                type: string
-                              divisor:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Specifies the output format of the exposed
-                                  resources, defaults to "1"
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              resource:
-                                description: 'Required: resource to select'
-                                type: string
-                            required:
-                              - resource
-                            type: object
-                          secretKeyRef:
-                            description: Selects a key of a secret in the pod's namespace
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key must
-                                  be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-                image:
-                  description: Docker image name.
-                  type: string
-                replicas:
-                  description: Replicas is the number of desired replicas.
-                  format: int32
-                  type: integer
-                serviceAccountName:
-                  description: Name of the service account associated with the policy
-                    server. Namespace service account will be used if not specified.
-                  type: string
-              required:
-                - image
-                - replicas
-              type: object
-            status:
-              description: PolicyServerStatus defines the observed state of PolicyServer
-              properties:
-                conditions:
-                  description: 'Conditions represent the observed conditions of the
-                  PolicyServer resource.  Known .status.conditions.types are: "PolicyServerSecretReconciled",
-                  "PolicyServerDeploymentReconciled" and "PolicyServerServiceReconciled"'
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition
-                          transitioned from one status to another. This should be when
-                          the underlying condition changed.  If that is not known, then
-                          using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: message is a human readable message indicating
-                          details about the transition. This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation
-                          that the condition was set based upon. For instance, if .metadata.generation
-                          is currently 12, but the .status.conditions[x].observedGeneration
-                          is 9, the condition is out of date with respect to the current
-                          state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: reason contains a programmatic identifier indicating
-                          the reason for the condition's last transition. Producers
-                          of specific condition types may define expected values and
-                          meanings for this field, and whether the values are considered
-                          a guaranteed API. The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                          --- Many .condition.type values are consistent across resources
-                          like Available, but because arbitrary conditions can be useful
-                          (see .node.status.conditions), the ability to deconflict is
-                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-              required:
-                - conditions
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              image:
+                description: Docker image name.
+                type: string
+              replicas:
+                description: Replicas is the number of desired replicas.
+                format: int32
+                type: integer
+              serviceAccountName:
+                description: Name of the service account associated with the policy server. Namespace service account will be used if not specified.
+                type: string
+            required:
+            - image
+            - replicas
+            type: object
+          status:
+            description: PolicyServerStatus defines the observed state of PolicyServer
+            properties:
+              conditions:
+                description: 'Conditions represent the observed conditions of the PolicyServer resource.  Known .status.conditions.types are: "PolicyServerSecretReconciled", "PolicyServerDeploymentReconciled" and "PolicyServerServiceReconciled"'
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/kubewarden-controller/templates/cert-tls.yaml
+++ b/charts/kubewarden-controller/templates/cert-tls.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.tls.useCertManager .Values.tls.useSelfSignedCert }}
+# cert-manager resources
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kubewarden-controller.fullname" . }}-serving-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - {{ include "kubewarden-controller.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+  - {{ include "kubewarden-controller.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "kubewarden-controller.fullname" . }}-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "kubewarden-controller.fullname" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/charts/kubewarden-controller/templates/cert-tls.yaml
+++ b/charts/kubewarden-controller/templates/cert-tls.yaml
@@ -1,4 +1,3 @@
-{{- if and .Values.tls.useCertManager .Values.tls.useSelfSignedCert }}
 # cert-manager resources
 ---
 apiVersion: cert-manager.io/v1
@@ -12,9 +11,14 @@ spec:
   - {{ include "kubewarden-controller.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
+{{- if eq .Values.tls.source "cert-manager-self-signed" }}
     name: {{ include "kubewarden-controller.fullname" . }}-selfsigned-issuer
+{{- else if eq .Values.tls.source "cert-manager" }}
+    name: {{ .Values.tls.certManagerIssuerName }}
+{{- end}}
   secretName: webhook-server-cert
 ---
+{{- if eq .Values.tls.source "cert-manager-self-signed" }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -53,6 +53,19 @@ spec:
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
       securityContext:
         runAsNonRoot: true
       terminationGracePeriodSeconds: 10

--- a/charts/kubewarden-controller/templates/policyserver-default.yaml
+++ b/charts/kubewarden-controller/templates/policyserver-default.yaml
@@ -4,6 +4,8 @@ metadata:
   name: default
   finalizers:
     - kubewarden
+  annotations:
+    "helm.sh/hook": "post-install"
 spec:
   image: {{ .Values.policyServer.image.repository }}:{{ .Values.policyServer.image.tag }}
   serviceAccountName: {{ .Values.policyServer.serviceAccountName }}

--- a/charts/kubewarden-controller/templates/service.yaml
+++ b/charts/kubewarden-controller/templates/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,3 +12,15 @@ spec:
     targetPort: https
   selector:
     {{- include "kubewarden-controller.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubewarden-controller.fullname" . }}-webhook-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+{{- include "kubewarden-controller.selectorLabels" . | nindent 4 }}

--- a/charts/kubewarden-controller/templates/webhooks.yaml
+++ b/charts/kubewarden-controller/templates/webhooks.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    {{- if .Values.tls.useCertManager }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/kubewarden-controller-serving-cert
+    {{- end }}
+  name: kubewarden-controller-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: {{ include "kubewarden-controller.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-policies-kubewarden-io-v1alpha2-clusteradmissionpolicy
+  failurePolicy: Fail
+  name: mclusteradmissionpolicy.kb.io
+  rules:
+  - apiGroups:
+    - policies.kubewarden.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    resources:
+    - clusteradmissionpolicies
+  sideEffects: None
+- admissionReviewVersions:
+    - v1
+    - v1beta1
+  clientConfig:
+    service:
+      name: {{ include "kubewarden-controller.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-policies-kubewarden-io-v1alpha2-policyserver
+  failurePolicy: Fail
+  name: mpolicyserver.kb.io
+  rules:
+    - apiGroups:
+        - policies.kubewarden.io
+      apiVersions:
+        - v1alpha2
+      operations:
+        - CREATE
+      resources:
+        - policyservers
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    {{- if .Values.tls.useCertManager }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/kubewarden-controller-serving-cert
+    {{- end }}
+  name: kubewarden-controller-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: {{ include "kubewarden-controller.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-policies-kubewarden-io-v1alpha2-clusteradmissionpolicy
+  failurePolicy: Fail
+  name: vclusteradmissionpolicy.kb.io
+  rules:
+  - apiGroups:
+    - policies.kubewarden.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusteradmissionpolicies
+  sideEffects: None

--- a/charts/kubewarden-controller/templates/webhooks.yaml
+++ b/charts/kubewarden-controller/templates/webhooks.yaml
@@ -3,9 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    {{- if .Values.tls.useCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kubewarden-controller.fullname" . }}-serving-cert
-    {{- end }}
   name: kubewarden-controller-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -53,9 +51,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    {{- if .Values.tls.useCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kubewarden-controller.fullname" . }}-serving-cert
-    {{- end }}
   name: kubewarden-controller-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/charts/kubewarden-controller/templates/webhooks.yaml
+++ b/charts/kubewarden-controller/templates/webhooks.yaml
@@ -4,7 +4,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     {{- if .Values.tls.useCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/kubewarden-controller-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kubewarden-controller.fullname" . }}-serving-cert
     {{- end }}
   name: kubewarden-controller-mutating-webhook-configuration
 webhooks:
@@ -54,7 +54,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     {{- if .Values.tls.useCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/kubewarden-controller-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kubewarden-controller.fullname" . }}-serving-cert
     {{- end }}
   name: kubewarden-controller-validating-webhook-configuration
 webhooks:

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -34,5 +34,12 @@ policyServer:
     - ingresses
 
 tls:
-  useCertManager: true
-  useSelfSignedCert: true
+  # source options:
+  # - "cert-manager-self-signed": Scaffold cert-manager integration, and create
+  #   a self-signed certificate with a cert-manager self-signed Issuer. Depends
+  #   on cert-manager. (default)
+  # - "cert-manager": Scafffold cert-manager integration. User configures their
+  #   own Issuer. Depends on cert-manager. Set tls.certManagerIssuerName to the
+  #   desired Issuer.
+  source: cert-manager-self-signed
+  certManagerIssuerName: "" # set when tls.source == cert-manager

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -32,3 +32,7 @@ policyServer:
   - apiGroup: "networking.k8s.io"
     resources:
     - ingresses
+
+tls:
+  useCertManager: true
+  useSelfSignedCert: true


### PR DESCRIPTION
- Add cert-manager as dependency, and template resources with its annotations, with `tls.useCertManager` (default `true`).
- Create cert-manager self-signed Issuer and Certificate, with `tls.useSelfSignedCert` (default `true`).
- Bump CRDs for new ClusterAdmissionPolicy.spec.status, add wehbook-server configuration for resources.
- Create default PolicyServer with a helm post-install hook (and use `helm install --wait`), as if not it will fail with the new webhooks.
- Update README.md

Part of https://github.com/kubewarden/helm-charts/issues/32.