### PR TITLE
Allow tuning of the default PolicyServer

### DIFF
--- a/charts/kubewarden-controller/templates/policyserver-default.yaml
+++ b/charts/kubewarden-controller/templates/policyserver-default.yaml
@@ -10,3 +10,11 @@ spec:
   image: {{ .Values.policyServer.image.repository }}:{{ .Values.policyServer.image.tag }}
   serviceAccountName: {{ .Values.policyServer.serviceAccountName }}
   replicas: {{ .Values.policyServer.replicaCount | default 1 }}
+  {{- with .Values.policyServer.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.policyServer.env }}
+  env:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -32,6 +32,8 @@ policyServer:
   - apiGroup: "networking.k8s.io"
     resources:
     - ingresses
+  env: []
+  annotations: {}
 
 tls:
   # source options:


### PR DESCRIPTION
Allow the user to specify some configuration values for the default PolicyServer object created by the chart.