### PR TITLE
OpenTelemetry: add integration

### DIFF
--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -30,6 +30,11 @@ spec:
         - --deployments-namespace={{ .Release.Namespace }}
         command:
         - /manager
+        {{- if .Values.policyServer.telemetry.enabled }}
+        env:
+          - name: KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT
+            value: "{{ .Values.policyServer.telemetry.metrics.port | default 8080 }}"
+        {{- end }}
         image: '{{ .Values.image.repository | default "ghcr.io/kubewarden/kubewarden-controller" }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:

--- a/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
+++ b/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
@@ -1,0 +1,39 @@
+{{ if .Values.policyServer.telemetry.enabled }}
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: kubewarden
+  namespace: {{ .Release.Namespace }}
+spec:
+  mode: sidecar
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+    processors:
+      batch:
+    exporters:
+      {{- if .Values.policyServer.telemetry.tracing.jaeger.endpoint }}
+      jaeger:
+        endpoint: {{ .Values.policyServer.telemetry.tracing.jaeger.endpoint }}
+      {{- end }}
+      {{- if .Values.policyServer.telemetry.metrics.port }}
+      prometheus:
+        endpoint: ":{{ .Values.policyServer.telemetry.metrics.port }}"
+      {{- end }}
+    service:
+      pipelines:
+        {{- if .Values.policyServer.telemetry.metrics.port }}
+        metrics:
+          receivers: [otlp]
+          processors: []
+          exporters: [prometheus]
+        {{- end }}
+        {{- if .Values.policyServer.telemetry.tracing.jaeger.endpoint }}
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [jaeger]
+        {{- end }}
+{{ end }}

--- a/charts/kubewarden-controller/templates/policyserver-default.yaml
+++ b/charts/kubewarden-controller/templates/policyserver-default.yaml
@@ -10,11 +10,23 @@ spec:
   image: {{ .Values.policyServer.image.repository }}:{{ .Values.policyServer.image.tag }}
   serviceAccountName: {{ .Values.policyServer.serviceAccountName }}
   replicas: {{ .Values.policyServer.replicaCount | default 1 }}
-  {{- with .Values.policyServer.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.policyServer.env }}
+    {{ if .Values.policyServer.telemetry.enabled }}
+      "sidecar.opentelemetry.io/inject": "true"
+    {{ end }}
+    {{- range $key, $value := .Values.policyServer.annotations }}
+      {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{ if or .Values.policyServer.env .Values.policyServer.telemetry.enabled }}
   env:
-    {{- toYaml . | nindent 2 }}
+    {{- if .Values.policyServer.telemetry.enabled }}
+    - name: KUBEWARDEN_ENABLE_METRICS
+      value: "1"
+    - name: KUBEWARDEN_LOG_FMT
+      value: otlp
+    {{- end }}
+    {{- range .Values.policyServer.env }}
+    - name: {{ .name | quote }}
+      value: {{ .value | quote }}
+    {{- end }}
   {{- end }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -22,17 +22,28 @@ policyServer:
     repository: ghcr.io/kubewarden/policy-server
     tag: "v0.2.1"
   serviceAccountName: policy-server
-# All permissions are cluster-wide. Even namespaced resources are
-# granted access in all namespaces at this time.
+  # All permissions are cluster-wide. Even namespaced resources are
+  # granted access in all namespaces at this time.
   permissions:
-  - apiGroup: ""
-    resources:
-    - namespaces
-    - services
-  - apiGroup: "networking.k8s.io"
-    resources:
-    - ingresses
-  env: []
+    - apiGroup: ""
+      resources:
+        - namespaces
+        - services
+    - apiGroup: "networking.k8s.io"
+      resources:
+        - ingresses
+  telemetry:
+    enabled: False
+    metrics:
+      port: 8080
+    tracing:
+      jaeger:
+        {}
+        # Jaeger endpoint to send traces to
+        # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:14250"
+  env:
+    - name: KUBEWARDEN_LOG_LEVEL
+      value: info
   annotations: {}
 
 tls:


### PR DESCRIPTION
Related: https://github.com/kubewarden/policy-server/issues/106

Add an initial OpenTelemetry integration to the helm charts.

The current configuration is not very flexible, in that it allows to change (or disable -- by using `null`) the metrics port. And the jaeger service to push traces to.

In other setups, where the agent (sidecar) collector, can send to other gateway collector running as a service in the cluster, this is not supported in this scheme.

There is always this balance between how easy we make to do a helm install without changing `values.yaml` that much, and how much freedom we let the user to configure.