### PR TITLE
Enable jekyll on gh-pages

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -71,3 +71,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./to-gh-pages
           keep_files: true
+          enable_jekyll: true


### PR DESCRIPTION
This serves the index.yaml and readme files.