### PR TITLE
Attempt to fix gh pages release

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -66,8 +66,9 @@ jobs:
           cp -f charts/README.md ./to-gh-pages
 
       - name: Deploy readme to GH pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./to-gh-pages
           keep_files: true
+          enable_jekyll: true


### PR DESCRIPTION
Ensure the `.nojekyll` file is not created. This prevents the gh-pages from rendering the contents of the `README.md`, which causes a 404 when opening https://charts.kubewarden.io
