### PR TITLE
Enable Kubewarden controller metrics.

### DIFF
--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -11,10 +11,13 @@ spec:
       {{- include "kubewarden-controller.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- range keys .Values.podAnnotations }}
+        {{ . | quote }}: {{ get $.Values.podAnnotations . | quote}}
+        {{- end }}
+        {{- if .Values.telemetry.enabled }}
+        "sidecar.opentelemetry.io/inject": "true"
+        {{- end }}
       labels:
         {{- include "kubewarden-controller.selectorLabels" . | nindent 8 }}
     spec:
@@ -28,9 +31,12 @@ spec:
         args:
         - --leader-elect
         - --deployments-namespace={{ .Release.Namespace }}
+       {{- if .Values.telemetry.enabled }}
+        - --enable-metrics
+       {{- end }}
         command:
         - /manager
-        {{- if .Values.policyServer.telemetry.enabled }}
+        {{- if .Values.telemetry.enabled }}
         env:
           - name: KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT
             value: "{{ .Values.policyServer.telemetry.metrics.port | default 8080 }}"

--- a/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
+++ b/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.policyServer.telemetry.enabled }}
+{{ if .Values.telemetry.enabled }}
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:

--- a/charts/kubewarden-controller/templates/policyserver-default.yaml
+++ b/charts/kubewarden-controller/templates/policyserver-default.yaml
@@ -11,15 +11,15 @@ spec:
   serviceAccountName: {{ .Values.policyServer.serviceAccountName }}
   replicas: {{ .Values.policyServer.replicaCount | default 1 }}
   annotations:
-    {{ if .Values.policyServer.telemetry.enabled }}
+    {{ if .Values.telemetry.enabled }}
       "sidecar.opentelemetry.io/inject": "true"
     {{ end }}
     {{- range $key, $value := .Values.policyServer.annotations }}
       {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
-  {{ if or .Values.policyServer.env .Values.policyServer.telemetry.enabled }}
+  {{ if or .Values.policyServer.env .Values.telemetry.enabled }}
   env:
-    {{- if .Values.policyServer.telemetry.enabled }}
+    {{- if .Values.telemetry.enabled }}
     - name: KUBEWARDEN_ENABLE_METRICS
       value: "1"
     - name: KUBEWARDEN_LOG_FMT

--- a/charts/kubewarden-controller/templates/service.yaml
+++ b/charts/kubewarden-controller/templates/service.yaml
@@ -7,6 +7,11 @@ metadata:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
 spec:
   ports:
+  {{- if .Values.telemetry.enabled }}
+  - name: metrics
+    port: 8080
+    targetPort: 8080
+  {{- end}}
   - name: https
     port: 8443
     targetPort: https

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -3,6 +3,8 @@ nameOverride: ""
 fullnameOverride: ""
 imagePullSecrets: []
 
+telemetry:
+  enabled: False
 image:
   # controller image to be used. Leave empty to use
   # ghcr.io/kubewarden/kubewarden-controller
@@ -33,7 +35,6 @@ policyServer:
       resources:
         - ingresses
   telemetry:
-    enabled: False
     metrics:
       port: 8080
     tracing:


### PR DESCRIPTION
Updates the Kubearden controller Helm chart to allow the user to enable metrics. Thus, OpenTelemetry can collect and expose these metrics to be collected by Prometheus.

This PR does not allow a fine-grain control of the metrics. This means that, if the user enables the telemetry. It will enable the metrics in the controller and policy servers. If we wanna allow the user to enable just for one component of the stack, I need to update the PR.