### PR TITLE
Bumps policy server version to v0.2.5.

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version of kubewarden-controller container image to be used
 appVersion: "v0.4.2"

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -22,7 +22,7 @@ policyServer:
   replicaCount: 1
   image:
     repository: ghcr.io/kubewarden/policy-server
-    tag: "v0.2.4"
+    tag: "v0.2.5"
   serviceAccountName: policy-server
   # All permissions are cluster-wide. Even namespaced resources are
   # granted access in all namespaces at this time.


### PR DESCRIPTION
Updates the policy server version to v0.2.5. This is the first version with the policy evaluation latency metric. 