### PR TITLE
Add default policy server settings

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 version: 0.4.2
 
 # This is the version of kubewarden-controller container image to be used
-appVersion: "v0.5.1"
+appVersion: "v0.5.2-rc"

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         args:
         - --leader-elect
         - --deployments-namespace={{ .Release.Namespace }}
+        {{- if .Values.common.policyServer.default.enabled }}
+        - --default-policy-server={{ .Values.common.policyServer.default.name }}
+        {{- end }}
        {{- if .Values.telemetry.enabled }}
         - --enable-metrics
        {{- end }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -46,3 +46,12 @@ resources:
     requests:
       cpu: 250m
       memory: 50Mi
+
+# Common settings cross multiple charts. These settings will be used
+# by more than one chart and they ideally need to match during the
+# installation of the charts consuming this values.
+common:
+  policyServer:
+    default:
+      name: default
+      enabled: true

--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -4,7 +4,6 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: {{ $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.name }}
 spec:
-  policyServer: {{ $.Values.policyServer.name }}
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
   module: {{ $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module }}
 {{ include "policy-namespace-selector" . | indent 2}}

--- a/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
@@ -4,7 +4,6 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: {{ $.Values.recommendedPolicies.hostNamespacePolicy.name }}
 spec:
-  policyServer: {{ $.Values.policyServer.name }}
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
   module: {{ $.Values.recommendedPolicies.hostNamespacePolicy.module }}
 {{ include "policy-namespace-selector" . | indent 2}}

--- a/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
+++ b/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
@@ -4,7 +4,6 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: {{ $.Values.recommendedPolicies.podPrivilegedPolicy.name }}
 spec:
-  policyServer: {{ $.Values.policyServer.name }}
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
   module: {{ $.Values.recommendedPolicies.podPrivilegedPolicy.module }}
 {{ include "policy-namespace-selector" . | indent 2}}

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.global.policyServer.default.enabled }}
+{{- if .Values.common.policyServer.default.enabled }}
 apiVersion: policies.kubewarden.io/v1alpha2
 kind: PolicyServer
 metadata:
-  name: {{ .Values.global.policyServer.default.name }}
+  name: {{ .Values.common.policyServer.default.name }}
   finalizers:
     - kubewarden
 spec:

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.global.policyServer.default.enabled }}
 apiVersion: policies.kubewarden.io/v1alpha2
 kind: PolicyServer
 metadata:
-  name: {{ .Values.policyServer.name }}
+  name: {{ .Values.global.policyServer.default.name }}
   finalizers:
     - kubewarden
 spec:
@@ -31,3 +32,4 @@ spec:
       value: {{ .value | quote }}
     {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/kubewarden-defaults/templates/user-group-policy.yaml
+++ b/charts/kubewarden-defaults/templates/user-group-policy.yaml
@@ -4,7 +4,6 @@ kind: ClusterAdmissionPolicy
 metadata:
   name: {{ $.Values.recommendedPolicies.userGroupPolicy.name }}
 spec:
-  policyServer: {{ $.Values.policyServer.name }}
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
   module: {{ $.Values.recommendedPolicies.userGroupPolicy.module }}
 {{ include "policy-namespace-selector" . | indent 2}}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -1,6 +1,5 @@
 # Policy Server settings
 policyServer:
-  name: "default"
   replicaCount: 1
   image:
     repository: ghcr.io/kubewarden/policy-server
@@ -62,3 +61,12 @@ recommendedPolicies:
   userGroupPolicy:
     module: "ghcr.io/kubewarden/policies/user-group-psp:v0.2.0"
     name: "do-not-run-as-root"
+
+# Common settings across multiple charts. These settings will be used
+# by more than one chart and they ideally need to match during the
+# installation of the charts consuming this values.
+common:
+  policyServer:
+    default:
+      name: default
+      enabled: true


### PR DESCRIPTION
Fixes: https://github.com/kubewarden/helm-charts/issues/76

This adds a global `values.yaml` file that can be consumed by the subcharts on certain attributes that might be shared across them.

For installation, the current documentation can be followed, running:

```
$ helm install --wait -n kubewarden --create-namespace kubewarden-crds charts/kubewarden-crds -f values.yaml
$ helm install --wait -n kubewarden kubewarden-controller charts/kubewarden-controller -f values.yaml
$ helm install --wait -n kubewarden kubewarden-defaults charts/kubewarden-defaults -f values.yaml
```

You can read more about global values at https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values