### PR TITLE
Skip releases if they already exist.

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -59,6 +59,7 @@ jobs:
           charts_dir: charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true
 
       - name: Prepare GH pages readme
         run: |


### PR DESCRIPTION
Updates the helm-chart-release.yml adding a environment variable to configure the helm chart releaser to skip the upload of a release which already exist.