### PR TITLE
Expose `policyServer.VerificationConfig` for default PolicyServer

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 version: 0.4.0
 
 # This is the version of kubewarden-controller container image to be used
-appVersion: "v0.5.0"
+appVersion: "v0.5.1"

--- a/charts/kubewarden-crds/templates/admissionpolicy.yaml
+++ b/charts/kubewarden-crds/templates/admissionpolicy.yaml
@@ -3,10 +3,20 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
     controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: admissionpolicies.policies.kubewarden.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: system
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: policies.kubewarden.io
   names:
     kind: AdmissionPolicy
@@ -34,14 +44,10 @@ spec:
         description: AdmissionPolicy is the Schema for the admissionpolicies API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -49,86 +55,40 @@ spec:
             description: AdmissionPolicySpec defines the desired state of AdmissionPolicy
             properties:
               failurePolicy:
-                description: FailurePolicy defines how unrecognized errors and timeout
-                  errors from the policy are handled. Allowed values are "Ignore"
-                  or "Fail". * "Ignore" means that an error calling the webhook is
-                  ignored and the API   request is allowed to continue. * "Fail" means
-                  that an error calling the webhook causes the admission to   fail
-                  and the API request to be rejected. The default behaviour is "Fail"
+                description: FailurePolicy defines how unrecognized errors and timeout errors from the policy are handled. Allowed values are "Ignore" or "Fail". * "Ignore" means that an error calling the webhook is ignored and the API   request is allowed to continue. * "Fail" means that an error calling the webhook causes the admission to   fail and the API request to be rejected. The default behaviour is "Fail"
                 type: string
               matchPolicy:
-                description: "matchPolicy defines how the \"rules\" list is used to
-                  match incoming requests. Allowed values are \"Exact\" or \"Equivalent\".
-                  \n - Exact: match a request only if it exactly matches a specified
-                  rule. For example, if deployments can be modified via apps/v1, apps/v1beta1,
-                  and extensions/v1beta1, but \"rules\" only included `apiGroups:[\"apps\"],
-                  apiVersions:[\"v1\"], resources: [\"deployments\"]`, a request to
-                  apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
-                  \n - Equivalent: match a request if modifies a resource listed in
-                  rules, even via another API group or version. For example, if deployments
-                  can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1,
-                  and \"rules\" only included `apiGroups:[\"apps\"], apiVersions:[\"v1\"],
-                  resources: [\"deployments\"]`, a request to apps/v1beta1 or extensions/v1beta1
-                  would be converted to apps/v1 and sent to the webhook. \n Defaults
-                  to \"Equivalent\""
+                description: "matchPolicy defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" or \"Equivalent\". \n - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but \"rules\" only included `apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook. \n - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and \"rules\" only included `apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook. \n Defaults to \"Equivalent\""
                 type: string
               mode:
                 default: protect
-                description: Mode defines the execution mode of this policy. Can be
-                  set to either "protect" or "monitor". If it's empty, it is defaulted
-                  to "protect". Transitioning this setting from "monitor" to "protect"
-                  is allowed, but is disallowed to transition from "protect" to "monitor".
-                  To perform this transition, the policy should be recreated in "monitor"
-                  mode instead.
+                description: Mode defines the execution mode of this policy. Can be set to either "protect" or "monitor". If it's empty, it is defaulted to "protect". Transitioning this setting from "monitor" to "protect" is allowed, but is disallowed to transition from "protect" to "monitor". To perform this transition, the policy should be recreated in "monitor" mode instead.
                 enum:
                 - protect
                 - monitor
                 type: string
               module:
-                description: Module is the location of the WASM module to be loaded.
-                  Can be a local file (file://), a remote file served by an HTTP server
-                  (http://, https://), or an artifact served by an OCI-compatible
-                  registry (registry://).
+                description: Module is the location of the WASM module to be loaded. Can be a local file (file://), a remote file served by an HTTP server (http://, https://), or an artifact served by an OCI-compatible registry (registry://).
                 type: string
               mutating:
-                description: Mutating indicates whether a policy has the ability to
-                  mutate incoming requests or not.
+                description: Mutating indicates whether a policy has the ability to mutate incoming requests or not.
                 type: boolean
               objectSelector:
-                description: ObjectSelector decides whether to run the webhook based
-                  on if the object has matching labels. objectSelector is evaluated
-                  against both the oldObject and newObject that would be sent to the
-                  webhook, and is considered to match if either object matches the
-                  selector. A null object (oldObject in the case of create, or newObject
-                  in the case of delete) or an object that cannot have labels (like
-                  a DeploymentRollback or a PodProxyOptions object) is not considered
-                  to match. Use the object selector only if the webhook is opt-in,
-                  because end users may skip the admission webhook by setting the
-                  labels. Default to the empty LabelSelector, which matches everything.
+                description: ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -140,11 +100,7 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               policyServer:
@@ -152,82 +108,46 @@ spec:
                 description: PolicyServer identifies an existing PolicyServer resource.
                 type: string
               rules:
-                description: Rules describes what operations on what resources/subresources
-                  the webhook cares about. The webhook cares about an operation if
-                  it matches _any_ Rule.
+                description: Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
                 items:
-                  description: RuleWithOperations is a tuple of Operations and Resources.
-                    It is recommended to make sure that all the tuple expansions are
-                    valid.
+                  description: RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.
                   properties:
                     apiGroups:
-                      description: APIGroups is the API groups the resources belong
-                        to. '*' is all groups. If '*' is present, the length of the
-                        slice must be one. Required.
+                      description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
                       items:
                         type: string
                       type: array
                     apiVersions:
-                      description: APIVersions is the API versions the resources belong
-                        to. '*' is all versions. If '*' is present, the length of
-                        the slice must be one. Required.
+                      description: APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
                       items:
                         type: string
                       type: array
                     operations:
-                      description: Operations is the operations the admission hook
-                        cares about - CREATE, UPDATE, DELETE, CONNECT or * for all
-                        of those operations and any future admission operations that
-                        are added. If '*' is present, the length of the slice must
-                        be one. Required.
+                      description: Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
                       items:
                         description: OperationType specifies an operation for a request.
                         type: string
                       type: array
                     resources:
-                      description: "Resources is a list of resources this rule applies
-                        to. \n For example: 'pods' means pods. 'pods/log' means the
-                        log subresource of pods. '*' means all resources, but not
-                        subresources. 'pods/*' means all subresources of pods. '*/scale'
-                        means all scale subresources. '*/*' means all resources and
-                        their subresources. \n If wildcard is present, the validation
-                        rule will ensure resources do not overlap with each other.
-                        \n Depending on the enclosing object, subresources might not
-                        be allowed. Required."
+                      description: "Resources is a list of resources this rule applies to. \n For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources. \n If wildcard is present, the validation rule will ensure resources do not overlap with each other. \n Depending on the enclosing object, subresources might not be allowed. Required."
                       items:
                         type: string
                       type: array
                     scope:
-                      description: scope specifies the scope of this rule. Valid values
-                        are "Cluster", "Namespaced", and "*" "Cluster" means that
-                        only cluster-scoped resources will match this rule. Namespace
-                        API objects are cluster-scoped. "Namespaced" means that only
-                        namespaced resources will match this rule. "*" means that
-                        there are no scope restrictions. Subresources match the scope
-                        of their parent resource. Default is "*".
+                      description: scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
                       type: string
                   type: object
                 type: array
               settings:
-                description: 'Settings is a free-form object that contains the policy
-                  configuration values. x-kubernetes-embedded-resource: false'
+                description: 'Settings is a free-form object that contains the policy configuration values. x-kubernetes-embedded-resource: false'
                 nullable: true
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               sideEffects:
-                description: 'SideEffects states whether this webhook has side effects.
-                  Acceptable values are: None, NoneOnDryRun (webhooks created via
-                  v1beta1 may also specify Some or Unknown). Webhooks with side effects
-                  MUST implement a reconciliation system, since a request may be rejected
-                  by a future step in the admission change and the side effects therefore
-                  need to be undone. Requests with the dryRun attribute will be auto-rejected
-                  if they match a webhook with sideEffects == Unknown or Some.'
+                description: 'SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.'
                 type: string
               timeoutSeconds:
-                description: TimeoutSeconds specifies the timeout for this webhook.
-                  After the timeout passes, the webhook call will be ignored or the
-                  API call will fail based on the failure policy. The timeout value
-                  must be between 1 and 30 seconds. Default to 10 seconds.
+                description: TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
                 format: int32
                 type: integer
             required:
@@ -235,55 +155,28 @@ spec:
             - rules
             type: object
           status:
-            description: PolicyStatus defines the observed state of ClusterAdmissionPolicy
-              and AdmissionPolicy
+            description: PolicyStatus defines the observed state of ClusterAdmissionPolicy and AdmissionPolicy
             properties:
               conditions:
-                description: 'Conditions represent the observed conditions of the
-                  ClusterAdmissionPolicy resource.  Known .status.conditions.types
-                  are: "PolicyServerSecretReconciled", "PolicyServerConfigMapReconciled",
-                  "PolicyServerDeploymentReconciled", "PolicyServerServiceReconciled"
-                  and "ClusterAdmissionPolicyActive"'
+                description: 'Conditions represent the observed conditions of the ClusterAdmissionPolicy resource.  Known .status.conditions.types are: "PolicyServerSecretReconciled", "PolicyServerConfigMapReconciled", "PolicyServerDeploymentReconciled", "PolicyServerServiceReconciled" and "ClusterAdmissionPolicyActive"'
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -296,11 +189,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -316,8 +205,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               policyStatus:
-                description: PolicyStatus represents whether this ClusterAdmissionPolicy
-                  is unscheduled, unschedulable, pending, or active.
+                description: PolicyStatus represents whether this ClusterAdmissionPolicy is unscheduled, unschedulable, pending, or active.
                 enum:
                 - unscheduled
                 - unschedulable

--- a/charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml
+++ b/charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml
@@ -1,13 +1,22 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
     controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: clusteradmissionpolicies.policies.kubewarden.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: system
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: policies.kubewarden.io
   names:
     kind: ClusterAdmissionPolicy
@@ -32,18 +41,13 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ClusterAdmissionPolicy is the Schema for the clusteradmissionpolicies
-          API
+        description: ClusterAdmissionPolicy is the Schema for the clusteradmissionpolicies API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -51,94 +55,40 @@ spec:
             description: ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy
             properties:
               failurePolicy:
-                description: FailurePolicy defines how unrecognized errors and timeout
-                  errors from the policy are handled. Allowed values are "Ignore"
-                  or "Fail". * "Ignore" means that an error calling the webhook is
-                  ignored and the API   request is allowed to continue. * "Fail" means
-                  that an error calling the webhook causes the admission to   fail
-                  and the API request to be rejected. The default behaviour is "Fail"
+                description: FailurePolicy defines how unrecognized errors and timeout errors from the policy are handled. Allowed values are "Ignore" or "Fail". * "Ignore" means that an error calling the webhook is ignored and the API   request is allowed to continue. * "Fail" means that an error calling the webhook causes the admission to   fail and the API request to be rejected. The default behaviour is "Fail"
                 type: string
               matchPolicy:
-                description: "matchPolicy defines how the \"rules\" list is used to
-                  match incoming requests. Allowed values are \"Exact\" or \"Equivalent\".
-                  \n - Exact: match a request only if it exactly matches a specified
-                  rule. For example, if deployments can be modified via apps/v1, apps/v1beta1,
-                  and extensions/v1beta1, but \"rules\" only included `apiGroups:[\"apps\"],
-                  apiVersions:[\"v1\"], resources: [\"deployments\"]`, a request to
-                  apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
-                  \n - Equivalent: match a request if modifies a resource listed in
-                  rules, even via another API group or version. For example, if deployments
-                  can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1,
-                  and \"rules\" only included `apiGroups:[\"apps\"], apiVersions:[\"v1\"],
-                  resources: [\"deployments\"]`, a request to apps/v1beta1 or extensions/v1beta1
-                  would be converted to apps/v1 and sent to the webhook. \n Defaults
-                  to \"Equivalent\""
+                description: "matchPolicy defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" or \"Equivalent\". \n - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but \"rules\" only included `apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook. \n - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and \"rules\" only included `apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook. \n Defaults to \"Equivalent\""
                 type: string
               mode:
                 default: protect
-                description: Mode defines the execution mode of this policy. Can be
-                  set to either "protect" or "monitor". If it's empty, it is defaulted
-                  to "protect". Transitioning this setting from "monitor" to "protect"
-                  is allowed, but is disallowed to transition from "protect" to "monitor".
-                  To perform this transition, the policy should be recreated in "monitor"
-                  mode instead.
+                description: Mode defines the execution mode of this policy. Can be set to either "protect" or "monitor". If it's empty, it is defaulted to "protect". Transitioning this setting from "monitor" to "protect" is allowed, but is disallowed to transition from "protect" to "monitor". To perform this transition, the policy should be recreated in "monitor" mode instead.
                 enum:
                 - protect
                 - monitor
                 type: string
               module:
-                description: Module is the location of the WASM module to be loaded.
-                  Can be a local file (file://), a remote file served by an HTTP server
-                  (http://, https://), or an artifact served by an OCI-compatible
-                  registry (registry://).
+                description: Module is the location of the WASM module to be loaded. Can be a local file (file://), a remote file served by an HTTP server (http://, https://), or an artifact served by an OCI-compatible registry (registry://).
                 type: string
               mutating:
-                description: Mutating indicates whether a policy has the ability to
-                  mutate incoming requests or not.
+                description: Mutating indicates whether a policy has the ability to mutate incoming requests or not.
                 type: boolean
               namespaceSelector:
-                description: "NamespaceSelector decides whether to run the webhook
-                  on an object based on whether the namespace for that object matches
-                  the selector. If the object itself is a namespace, the matching
-                  is performed on object.metadata.labels. If the object is another
-                  cluster scoped resource, it never skips the webhook. \n For example,
-                  to run the webhook on any objects whose namespace is not associated
-                  with \"runlevel\" of \"0\" or \"1\";  you will set the selector
-                  as follows: \"namespaceSelector\": {   \"matchExpressions\": [     {
-                  \      \"key\": \"runlevel\",       \"operator\": \"NotIn\",       \"values\":
-                  [         \"0\",         \"1\"       ]     }   ] } \n If instead
-                  you want to only run the webhook on any objects whose namespace
-                  is associated with the \"environment\" of \"prod\" or \"staging\";
-                  you will set the selector as follows: \"namespaceSelector\": {   \"matchExpressions\":
-                  [     {       \"key\": \"environment\",       \"operator\": \"In\",
-                  \      \"values\": [         \"prod\",         \"staging\"       ]
-                  \    }   ] } \n See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-                  for more examples of label selectors. \n Default to the empty LabelSelector,
-                  which matches everything."
+                description: "NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook. \n For example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {   \"matchExpressions\": [     {       \"key\": \"runlevel\",       \"operator\": \"NotIn\",       \"values\": [         \"0\",         \"1\"       ]     }   ] } \n If instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {   \"matchExpressions\": [     {       \"key\": \"environment\",       \"operator\": \"In\",       \"values\": [         \"prod\",         \"staging\"       ]     }   ] } \n See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels for more examples of label selectors. \n Default to the empty LabelSelector, which matches everything."
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -150,48 +100,25 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               objectSelector:
-                description: ObjectSelector decides whether to run the webhook based
-                  on if the object has matching labels. objectSelector is evaluated
-                  against both the oldObject and newObject that would be sent to the
-                  webhook, and is considered to match if either object matches the
-                  selector. A null object (oldObject in the case of create, or newObject
-                  in the case of delete) or an object that cannot have labels (like
-                  a DeploymentRollback or a PodProxyOptions object) is not considered
-                  to match. Use the object selector only if the webhook is opt-in,
-                  because end users may skip the admission webhook by setting the
-                  labels. Default to the empty LabelSelector, which matches everything.
+                description: ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
+                          description: key is the label key that the selector applies to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                           items:
                             type: string
                           type: array
@@ -203,11 +130,7 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
               policyServer:
@@ -215,82 +138,46 @@ spec:
                 description: PolicyServer identifies an existing PolicyServer resource.
                 type: string
               rules:
-                description: Rules describes what operations on what resources/subresources
-                  the webhook cares about. The webhook cares about an operation if
-                  it matches _any_ Rule.
+                description: Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule.
                 items:
-                  description: RuleWithOperations is a tuple of Operations and Resources.
-                    It is recommended to make sure that all the tuple expansions are
-                    valid.
+                  description: RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.
                   properties:
                     apiGroups:
-                      description: APIGroups is the API groups the resources belong
-                        to. '*' is all groups. If '*' is present, the length of the
-                        slice must be one. Required.
+                      description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
                       items:
                         type: string
                       type: array
                     apiVersions:
-                      description: APIVersions is the API versions the resources belong
-                        to. '*' is all versions. If '*' is present, the length of
-                        the slice must be one. Required.
+                      description: APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
                       items:
                         type: string
                       type: array
                     operations:
-                      description: Operations is the operations the admission hook
-                        cares about - CREATE, UPDATE, DELETE, CONNECT or * for all
-                        of those operations and any future admission operations that
-                        are added. If '*' is present, the length of the slice must
-                        be one. Required.
+                      description: Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
                       items:
                         description: OperationType specifies an operation for a request.
                         type: string
                       type: array
                     resources:
-                      description: "Resources is a list of resources this rule applies
-                        to. \n For example: 'pods' means pods. 'pods/log' means the
-                        log subresource of pods. '*' means all resources, but not
-                        subresources. 'pods/*' means all subresources of pods. '*/scale'
-                        means all scale subresources. '*/*' means all resources and
-                        their subresources. \n If wildcard is present, the validation
-                        rule will ensure resources do not overlap with each other.
-                        \n Depending on the enclosing object, subresources might not
-                        be allowed. Required."
+                      description: "Resources is a list of resources this rule applies to. \n For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources. \n If wildcard is present, the validation rule will ensure resources do not overlap with each other. \n Depending on the enclosing object, subresources might not be allowed. Required."
                       items:
                         type: string
                       type: array
                     scope:
-                      description: scope specifies the scope of this rule. Valid values
-                        are "Cluster", "Namespaced", and "*" "Cluster" means that
-                        only cluster-scoped resources will match this rule. Namespace
-                        API objects are cluster-scoped. "Namespaced" means that only
-                        namespaced resources will match this rule. "*" means that
-                        there are no scope restrictions. Subresources match the scope
-                        of their parent resource. Default is "*".
+                      description: scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
                       type: string
                   type: object
                 type: array
               settings:
-                description: 'Settings is a free-form object that contains the policy
-                  configuration values. x-kubernetes-embedded-resource: false'
+                description: 'Settings is a free-form object that contains the policy configuration values. x-kubernetes-embedded-resource: false'
                 nullable: true
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               sideEffects:
-                description: 'SideEffects states whether this webhook has side effects.
-                  Acceptable values are: None, NoneOnDryRun (webhooks created via
-                  v1beta1 may also specify Some or Unknown). Webhooks with side effects
-                  MUST implement a reconciliation system, since a request may be rejected
-                  by a future step in the admission change and the side effects therefore
-                  need to be undone. Requests with the dryRun attribute will be auto-rejected
-                  if they match a webhook with sideEffects == Unknown or Some.'
+                description: 'SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.'
                 type: string
               timeoutSeconds:
-                description: TimeoutSeconds specifies the timeout for this webhook.
-                  After the timeout passes, the webhook call will be ignored or the
-                  API call will fail based on the failure policy. The timeout value
-                  must be between 1 and 30 seconds. Default to 10 seconds.
+                description: TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
                 format: int32
                 type: integer
             required:
@@ -298,55 +185,28 @@ spec:
             - rules
             type: object
           status:
-            description: PolicyStatus defines the observed state of ClusterAdmissionPolicy
-              and AdmissionPolicy
+            description: PolicyStatus defines the observed state of ClusterAdmissionPolicy and AdmissionPolicy
             properties:
               conditions:
-                description: 'Conditions represent the observed conditions of the
-                  ClusterAdmissionPolicy resource.  Known .status.conditions.types
-                  are: "PolicyServerSecretReconciled", "PolicyServerConfigMapReconciled",
-                  "PolicyServerDeploymentReconciled", "PolicyServerServiceReconciled"
-                  and "ClusterAdmissionPolicyActive"'
+                description: 'Conditions represent the observed conditions of the ClusterAdmissionPolicy resource.  Known .status.conditions.types are: "PolicyServerSecretReconciled", "PolicyServerConfigMapReconciled", "PolicyServerDeploymentReconciled", "PolicyServerServiceReconciled" and "ClusterAdmissionPolicyActive"'
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -359,11 +219,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -379,8 +235,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               policyStatus:
-                description: PolicyStatus represents whether this ClusterAdmissionPolicy
-                  is unscheduled, unschedulable, pending, or active.
+                description: PolicyStatus represents whether this ClusterAdmissionPolicy is unscheduled, unschedulable, pending, or active.
                 enum:
                 - unscheduled
                 - unschedulable

--- a/charts/kubewarden-crds/templates/policyserver.yaml
+++ b/charts/kubewarden-crds/templates/policyserver.yaml
@@ -3,9 +3,20 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
     controller-gen.kubebuilder.io/version: v0.4.1
   name: policyservers.policies.kubewarden.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: system
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: policies.kubewarden.io
   names:
     kind: PolicyServer
@@ -140,6 +151,9 @@ spec:
                   type: array
                 description: Key value map of registry URIs endpoints to a list of their associated PEM encoded certificate authorities that have to be used to verify the certificate used by the endpoint.
                 type: object
+              verificationConfig:
+                description: Name of VerificationConfig configmap in the same namespace, containing Sigstore verification configuration. The configuration must be under a key named verification-config in the Configmap.
+                type: string
             required:
             - image
             - replicas

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -8,6 +8,9 @@ spec:
   image: {{ .Values.policyServer.image.repository }}:{{ .Values.policyServer.image.tag }}
   serviceAccountName: {{ .Values.policyServer.serviceAccountName }}
   replicas: {{ .Values.policyServer.replicaCount | default 1 }}
+  {{- if .Values.policyServer.verificationConfig }}
+  verificationConfig: {{ .Values.policyServer.verificationConfig }}
+  {{- end }}
   annotations:
     {{ if .Values.policyServer.telemetry.enabled }}
       "sidecar.opentelemetry.io/inject": "true"

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -6,9 +6,12 @@ policyServer:
     repository: ghcr.io/kubewarden/policy-server
     tag: "v0.2.6"
   serviceAccountName: policy-server
-  # All permissions are cluster-wide. Even namespaced resources are
-  # granted access in all namespaces at this time.
+  # verificationConfig: your_configmap
+    # Configmap containing a Sigstore verification configuration under a key
+    # named `verification-config`. Must be on the same ns as the PolicyServer.
   permissions:
+    # All permissions are cluster-wide. Even namespaced resources are
+    # granted access in all namespaces at this time.
     - apiGroup: ""
       resources:
         - namespaces

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -4,7 +4,7 @@ policyServer:
   replicaCount: 1
   image:
     repository: ghcr.io/kubewarden/policy-server
-    tag: "v0.2.6"
+    tag: "v0.2.7"
   serviceAccountName: policy-server
   # verificationConfig: your_configmap
     # Configmap containing a Sigstore verification configuration under a key


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/helm-charts/issues/68
Depends on https://github.com/kubewarden/kubewarden-controller/pull/193
Depends on https://github.com/kubewarden/kubewarden-controller/pull/194

Consumes new versions of controller, policy-server, and crds that allow for Sigstore verification.
On `kubewarden-defaults` chart: Expose `policyServer.VerificationConfig` for default PolicyServer

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

```shell
kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
helm install --wait -n kubewarden --create-namespace kubewarden-crds ./kubewarden-crds
helm install --wait -n kubewarden kubewarden-controller ./kubewarden-controller
helm install --set image.tag=latest --wait -n kubewarden kubewarden-defaults ./kubewarden-defaults
helm upgrade --set policyServer.verificationConfig=my-verification-config --set policyServer.image.tag=0.2.7 --wait -n kubewarden kubewarden-defaults ./kubewarden-defaults
```
and then instantiate a kubewarden policy.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
