### PR TITLE
Bump kubewarden-controller version.

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version of kubewarden-controller container image to be used
 appVersion: "v0.5.0"


### PR DESCRIPTION
Bumps kubewarden-controller version to trigger a new release. This is necessary due an issue in the release process.
