### PR TITLE
Bumps kubewarden-controller and kubewarden-crds versions.

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version of kubewarden-controller container image to be used
 appVersion: "v0.5.1"

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3


### PR DESCRIPTION
## Description

Bumps kubewarden-controller version to v0.4.2 and kubewarden-crds version to v0.1.3 to mark the release of the secure supply chain changes.