### PR TITLE
Controller pod permissions.

### DIFF
--- a/charts/kubewarden-controller/templates/rbac.yaml
+++ b/charts/kubewarden-controller/templates/rbac.yaml
@@ -46,6 +46,7 @@ rules:
   - secrets
   - services
   - configmaps
+  - pods
   verbs:
   - get
   - create
@@ -53,6 +54,7 @@ rules:
   - update
   - delete
   - list
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -85,7 +87,9 @@ rules:
   resources:
   - configmaps
   - secrets
+  - pods
   verbs:
+  - get
   - list
   - watch
 - apiGroups:


### PR DESCRIPTION
Updates the roles used by the Kubewarden controller to allow the process access pod resources information. This is necessary due the latest changes in the controller where it watches for pod updates.


Related to https://github.com/kubewarden/kubewarden-controller/pull/199