### PR TITLE
Add missing policyServer configuration values.

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -11,5 +11,5 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 

--- a/charts/kubewarden-defaults/README.md
+++ b/charts/kubewarden-defaults/README.md
@@ -84,7 +84,7 @@ chart and their default values.
 | `policyServer.image.repository`          | The `policy-server` container image to be used                                                                           | `ghcr.io/kubewarden/policy-server` |
 | `policyServer.image.tag`                 | The tag of the `policy-server` container image to be used                                                                | ``                  |
 | `policyServer.telemetry.enabled`         | Enable OpenTelemetry configuration                                                                                       | `False`             |
-| `policyServer.imagePullSecret`           | Name of ImagePullSecret secret in the same namespace, used for pulling policies from repositories.                       | ``                  |
+| `policyServer.imagePullSecret` | Name of ImagePullSecret secret in the same namespace, used both for pulling the container images and the policies from OCI repositories. | `` |
 | `policyServer.insecureSources`           | List of insecure URIs to policy repositories.                                                                            | `[]`                |
 | `policyServer.sourceAuthorities`         | Registry URIs endpoints to a list of their associated PEM encoded certificate authorities that have to be used to verify the certificate used by the endpoint. | `{}` |
 | `recommendedPolicies.enabled`            | Install the recommended policies                                                                                         | `False`             |

--- a/charts/kubewarden-defaults/README.md
+++ b/charts/kubewarden-defaults/README.md
@@ -35,8 +35,7 @@ helm install --set recommendedPolicies.enabled=True --set recommendedPolicies.sk
 **WARNING**
 Enforcing the policies to the `kube-system` namespace could break your cluster.
 Be aware that some pods could need break this rules. Therefore, the user must be
-sure which namespaces the policies will be applied. Remember that when you
-define the `--set` command line flag the default values are overwritten. So, the
+sure which namespaces the policies will be applied. Remember that when you define the `--set` command line flag the default values are overwritten. So, the
 user must define the `kube-system` namespace manually.
 
 Check out the configuration section to see all the configuration options.
@@ -85,6 +84,9 @@ chart and their default values.
 | `policyServer.image.repository`          | The `policy-server` container image to be used                                                                           | `ghcr.io/kubewarden/policy-server` |
 | `policyServer.image.tag`                 | The tag of the `policy-server` container image to be used                                                                | ``                  |
 | `policyServer.telemetry.enabled`         | Enable OpenTelemetry configuration                                                                                       | `False`             |
+| `policyServer.imagePullSecret`           | Name of ImagePullSecret secret in the same namespace, used for pulling policies from repositories.                       | ``                  |
+| `policyServer.insecureSources`           | List of insecure URIs to policy repositories.                                                                            | `[]`                |
+| `policyServer.sourceAuthorities`         | Registry URIs endpoints to a list of their associated PEM encoded certificate authorities that have to be used to verify the certificate used by the endpoint. | `{}` |
 | `recommendedPolicies.enabled`            | Install the recommended policies                                                                                         | `False`             |
 | `recommendedPolicies.skipNamespaces`     | Recommended policies should ignore resources from these namespaces                                                       | `[calico-system, cattle-alerting, cattle-fleet-local-system, cattle-fleet-system, cattle-global-data, cattle-global-nt, cattle-impersonation-system, cattle-istio, cattle-logging, cattle-pipeline, cattle-prometheus, cattle-system, cert-manager, ingress-nginx, kube-node-lease, kube-public, kube-system, rancher-operator-system, security-scan, tigera-operator]` |
 | `recommendedPolicies.defaultPolicyMode`  | The policy mode used in all default policies                                                                             | `monitor`           |

--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -24,6 +24,37 @@ policyServer:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info
   annotations: {}
+  # imagePullSecret stores the secret name used to pull images from repositories.
+  # The secret should be in the same namespace of the Policy Server
+  #
+  # Example of usage:
+  # imagePullSecret: "mysecret"
+  imagePullSecret:
+
+  # insecureSources store a list of allowed insecure restrigies.
+  #
+  # Example of usage:
+  #insecureSources:
+  #  - "source1"
+  #  - "source2"
+  insecureSources:
+
+  # sourceAuthorities is a list of the URIs and their PEM encoded certificates
+  # used to authenticate them
+  #
+  # Example of usage:
+  # sourceAuthorities:
+  #   - uri: "uri1"
+  #     certs:
+  #       - "cert1"
+  #       - "cert2"
+  #   - uri: "uri2"
+  #     certs:
+  #       - "cert3"
+  #   - uri: "uri3"
+  #     certs:
+  #       - "cert4"
+  sourceAuthorities:
 
 recommendedPolicies:
   enabled: False

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -13,13 +13,13 @@ spec:
   verificationConfig: {{ .Values.policyServer.verificationConfig }}
   {{- end }}
   annotations:
-    {{ if .Values.policyServer.telemetry.enabled }}
+    {{- if .Values.policyServer.telemetry.enabled }}
       "sidecar.opentelemetry.io/inject": "true"
-    {{ end }}
+    {{- end }}
     {{- range $key, $value := .Values.policyServer.annotations }}
       {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
-  {{ if or .Values.policyServer.env .Values.policyServer.telemetry.enabled }}
+  {{- if or .Values.policyServer.env .Values.policyServer.telemetry.enabled }}
   env:
     {{- if .Values.policyServer.telemetry.enabled }}
     - name: KUBEWARDEN_ENABLE_METRICS
@@ -33,3 +33,23 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+  {{- if .Values.policyServer.imagePullSecret }}
+  imagePullSecret: {{ .Values.policyServer.imagePullSecret | quote }}
+  {{- end }}
+  {{- if .Values.policyServer.insecureSources }}
+  insecureSources:
+  {{- range $source := .Values.policyServer.insecureSources }}
+    - {{ $source | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.policyServer.sourceAuthorities }}
+  sourceAuthorities:
+  {{- range .Values.policyServer.sourceAuthorities }}
+  {{- if .certs }}
+    {{ .uri }}:
+  {{- range .certs }}
+      - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -35,6 +35,37 @@ policyServer:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info
   annotations: {}
+  # imagePullSecret stores the secret name used to pull images from repositories.
+  # The secret should be in the same namespace of the Policy Server
+  #
+  # Example of usage:
+  # imagePullSecret: "mysecret"
+  imagePullSecret:
+
+  # insecureSources store a list of allowed insecure restrigies.
+  #
+  # Example of usage:
+  #insecureSources:
+  #  - "source1"
+  #  - "source2"
+  insecureSources:
+
+  # sourceAuthorities is a list of the URIs and their PEM encoded certificates
+  # used to authenticate them
+  #
+  # Example of usage:
+  # sourceAuthorities:
+  #   - uri: "uri1"
+  #     certs:
+  #       - "cert1"
+  #       - "cert2"
+  #   - uri: "uri2"
+  #     certs:
+  #       - "cert3"
+  #   - uri: "uri3"
+  #     certs:
+  #       - "cert4"
+  sourceAuthorities:
 
 recommendedPolicies:
   enabled: False


### PR DESCRIPTION
Adds the values `imagePullSecret`, `insecureSources` and `sourceAuthorities`
allowing the users to configure the policy server configuration with the
same name.

Fix #84 
