### PR TITLE
Telemetry should be disabled by default.

### DIFF
--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -19,7 +19,7 @@ policyServer:
       resources:
         - ingresses
   telemetry:
-    enabled: True
+    enabled: False
   env:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -30,7 +30,7 @@ policyServer:
       resources:
         - ingresses
   telemetry:
-    enabled: True
+    enabled: False
   env:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info


### PR DESCRIPTION
Our README.md shows the telemetry disable by default. However, it is enabled by default in the chart-values.yaml file. Therefore, this commit change it disabling it again.
