### PR TITLE
The allow privileged escalation policy should be able to mutate.

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5

--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -14,7 +14,7 @@ spec:
     operations:
     - CREATE
     - UPDATE
-  mutating: false
+  mutating: true
   settings:
     default_allow_privilege_escalation: false
 {{ end }}


### PR DESCRIPTION
The recommended policy to control privileged escalation requires the permission to mutate requests. However, the policy definition does not allow the policy to mutate requests. This commit fixes that changing the mutating flag to "true". Therefore, the policy can run properly.

Issue found during testing for the issue https://github.com/kubewarden/policy-server/issues/260
