### PR TITLE
feat: Use `kubewarden/kubectl` image which is signed

### DIFF
--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -19,6 +19,13 @@ image:
   # image tag, leave empty to use chart's AppVersion
   tag: ""
 
+preDeleteJob:
+  image:
+    # kubectl image to be used in the pre-delete helm hook. Leave empty to use
+    # ghcr.io/kubewarden/kubectl
+    repository: ""
+    tag: "v1.23.3"
+
 podAnnotations: {}
 nodeSelector: {}
 tolerations: []

--- a/charts/kubewarden-controller/templates/pre-delete-hook.yaml
+++ b/charts/kubewarden-controller/templates/pre-delete-hook.yaml
@@ -24,5 +24,5 @@ spec:
       serviceAccountName: {{ include "kubewarden-controller.serviceAccountName" . }}
       containers:
         - name: pre-delete-job
-          image: "rancher/kubectl:v1.21.4"
+          image: '{{ .Values.preDeleteJob.image.repository | default "ghcr.io/kubewarden/kubectl" }}:{{ .Values.preDeleteJob.image.tag }}'
           command: ["kubectl", "delete", "--all", "policyservers.policies.kubewarden.io"]

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -30,6 +30,13 @@ image:
   # image tag, leave empty to use chart's AppVersion
   tag: ""
 
+preDeleteJob:
+  image:
+    # kubectl image to be used in the pre-delete helm hook. Leave empty to use
+    # ghcr.io/kubewarden/kubectl
+    repository: ""
+    tag: "v1.23.3"
+
 podAnnotations: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
## Description

Use `kubewarden/kubectl` image, which is signed, instead of `rancher-kubectl`.
Parametrize the image with values.yaml.

## Test
Tested the pre-delete hook locally, with an image built by the same code as https://github.com/kubewarden/rancher-kubectl-builder/pull/2 (ghcr.io/viccuad/kubectl)

## Additional Information

Depends on https://github.com/kubewarden/rancher-kubectl-builder/pull/2, and that workflow being run and new images being generated.
