### PR TITLE
remove v1alpha2 from webhooks

### DIFF
--- a/charts/kubewarden-controller/templates/webhooks.yaml
+++ b/charts/kubewarden-controller/templates/webhooks.yaml
@@ -20,7 +20,6 @@ webhooks:
   - apiGroups:
     - policies.kubewarden.io
     apiVersions:
-    - v1alpha2
     - v1
     operations:
     - CREATE
@@ -42,7 +41,6 @@ webhooks:
     - apiGroups:
         - policies.kubewarden.io
       apiVersions:
-        - v1alpha2
         - v1
       operations:
         - CREATE
@@ -65,7 +63,6 @@ webhooks:
         - policies.kubewarden.io
       apiVersions:
         - v1
-        - v1alpha2
       operations:
         - CREATE
         - UPDATE
@@ -96,7 +93,6 @@ webhooks:
     - policies.kubewarden.io
     apiVersions:
     - v1
-    - v1alpha2
     operations:
     - CREATE
     - UPDATE
@@ -118,7 +114,6 @@ webhooks:
     - policies.kubewarden.io
     apiVersions:
     - v1
-    - v1alpha2
     operations:
     - CREATE
     - UPDATE


### PR DESCRIPTION
We are converting v1alpha2 resources into v1 using the [None conversion strategy](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#overview)
If we add both apiVersions v1 and v1alpha2 to the webhooks we can't create v1alpha2 resources. I get the following error:

```
 Error from server: error when creating "verify.yaml": admission webhook "mclusteradmissionpolicy.kb.io" denied the request: unable to decode policies.kubewarden.io/v1alpha2, Kind=ClusterAdmissionPolicy into *v1.ClusterAdmissionPolicy
```

