### PR TITLE
feat: Install latest Helm 3.* in GHA

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.8.0
+          version: 3.*
 
       - name: Install cosign
         uses: sigstore/cosign-installer@main


### PR DESCRIPTION
## Description

With the new install-helm v3 action, we can just ask for the latest Helm 3.* version.