### PR TITLE
Consume Policy Server v1.1.1

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1

--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -3,7 +3,7 @@ policyServer:
   replicaCount: 1
   image:
     repository: ghcr.io/kubewarden/policy-server
-    tag: "v1.1.0"
+    tag: "v1.1.1"
   serviceAccountName: policy-server
   # verificationConfig: your_configmap
     # Configmap containing a Sigstore verification configuration under a key

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -14,7 +14,7 @@ policyServer:
   replicaCount: 1
   image:
     repository: ghcr.io/kubewarden/policy-server
-    tag: "v1.1.0"
+    tag: "v1.1.1"
   serviceAccountName: policy-server
   # verificationConfig: your_configmap
     # Configmap containing a Sigstore verification configuration under a key


### PR DESCRIPTION
Use the latest patch release of Policy Server. This is required to have a workaround for an issue with the Sigstore TUF repository.