### PR TITLE
feat: add policies to control host paths and container capabilities.

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2

--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -93,3 +93,16 @@ recommendedPolicies:
   userGroupPolicy:
     module: "ghcr.io/kubewarden/policies/user-group-psp:v0.2.0"
     name: "do-not-run-as-root"
+  hostPathsPolicy:
+    module: "ghcr.io/kubewarden/policies/hostpaths-psp:v0.1.5"
+    name: "do-not-share-host-paths"
+    paths:
+      - pathPrefix: "/tmp"
+        readOnly: true
+  capabilitiesPolicy:
+    module: "ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9"
+    name: "drop-capabilities"
+    allowed_capabilities:
+    required_drop_capabilities:
+      - ALL
+    default_add_capabilities:

--- a/charts/kubewarden-defaults/templates/capabilities-policy.yaml
+++ b/charts/kubewarden-defaults/templates/capabilities-policy.yaml
@@ -1,0 +1,32 @@
+{{ if .Values.recommendedPolicies.enabled }}
+apiVersion: {{ $.Values.crdVersion }}
+kind: ClusterAdmissionPolicy
+metadata:
+  name: {{ $.Values.recommendedPolicies.capabilitiesPolicy.name }}
+spec:
+  mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
+  module: {{ $.Values.recommendedPolicies.capabilitiesPolicy.module }}
+{{ include "policy-namespace-selector" . | indent 2}}
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations:
+    - CREATE
+    - UPDATE
+  mutating: true
+  settings:
+      allowed_capabilities:
+{{- range .Values.recommendedPolicies.capabilitiesPolicy.allowed_capabilities }}
+        - {{ . }}
+{{- end }}
+      required_drop_capabilities:
+{{- range .Values.recommendedPolicies.capabilitiesPolicy.required_drop_capabilities }}
+        - {{ . }}
+{{- end }}
+      default_add_capabilities:
+{{- range .Values.recommendedPolicies.capabilitiesPolicy.default_add_capabilities }}
+        - {{ . }}
+{{- end }}
+
+{{ end }}

--- a/charts/kubewarden-defaults/templates/host-path-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-path-policy.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.recommendedPolicies.enabled }}
+apiVersion: {{ $.Values.crdVersion }}
+kind: ClusterAdmissionPolicy
+metadata:
+  name: {{ $.Values.recommendedPolicies.hostPathsPolicy.name }}
+spec:
+  mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
+  module: {{ $.Values.recommendedPolicies.hostPathsPolicy.module }}
+{{ include "policy-namespace-selector" . | indent 2}}
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations:
+    - CREATE
+    - UPDATE
+  mutating: false
+  settings:
+    allowedHostPaths:
+{{- range .Values.recommendedPolicies.hostPathsPolicy.paths }}
+    - pathPrefix:  {{ .pathPrefix | quote }}
+      readOnly: {{ .readOnly  }}
+{{- end }}
+{{ end }}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -104,3 +104,16 @@ recommendedPolicies:
   userGroupPolicy:
     module: "ghcr.io/kubewarden/policies/user-group-psp:v0.2.0"
     name: "do-not-run-as-root"
+  hostPathsPolicy:
+    module: "ghcr.io/kubewarden/policies/hostpaths-psp:v0.1.5"
+    name: "do-not-share-host-paths"
+    paths:
+      - pathPrefix: "/tmp"
+        readOnly: true
+  capabilitiesPolicy:
+    module: "ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9"
+    name: "drop-capabilities"
+    allowed_capabilities:
+    required_drop_capabilities:
+      - ALL
+    default_add_capabilities:


### PR DESCRIPTION
Adds two more recommended policies. The first policy will control which host paths can be used with the `hostPath` volume type. The second one will ensure that no container will have more Linux capabilities than necessary.

Fix #90 
Fix #91 