### PR TITLE
merge docs into values.yaml, bump kubewarden-controller & kubewarden-charts

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 version: 1.1.0
 
 # This is the version of kubewarden-controller container image to be used
-appVersion: "v1.1.0"
+appVersion: "v1.1.1"

--- a/charts/kubewarden-controller/README.md
+++ b/charts/kubewarden-controller/README.md
@@ -56,27 +56,10 @@ If you want to keep the history use `--keep-history` flag.
 
 ## Configuration
 
-The following tables list the configurable parameters of the kubewarden-controller
-chart and their default values.
+See the `values.yaml` file of the chart for the configuration values.
 
-| Parameter                          | Description                                                                                                              | Default             |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------- |
-| `nameOverride`                     | Replaces the name of the chart in the `Chart.yaml` file when this is is used to construct Kubernetes object names         | ``                  |
-| `fullnameOverride`                 | Completely replaces the generated name                                                                                   | ``                  |
-| `imagePullSecrets`                 | Secrets to be used to pull container images from a Private Registry. Refer to [official Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) | `[]` |
-| `image.repository`                 | The `kubewarden-controller` container image to be used                                                                      | `ghcr.io/kubewarden/kubewarden-controller` |
-| `image.tag`                        | The tag of the `kubewarden-controller` container image to be used. When left empty chart's `AppVersion` is going to be used | ``                  |
-| `podAnnotations`                   | Extra annotations to add to the `kubewarden-controller` deployment                                                          | `{}`                |
-| `nodeSelector`                     | `nodeSelector` for the `kubewarden-controller` deployment                                                                   | `{}`                |
-| `tolerations`                      | `tolerations` for the `kubewarden-controller` deployment                                                                    | `{}`                |
-| `affinity`                         | `affinity` rules for the `kubewarden-controller` deployment                                                                 | `{}`                |
-| `tls.source`                       | Source of the TLS cert for webhooks: `cert-manager-self-signed`, `cert-manager`                                          | `cert-manager-self-signed` |
-| `tls.certManagerIssuerName`        | Name of cert-manager Issuer configured by user, when `tls.source` is `cert-manager`                                      | `cert-manager-self-signed` |
-| `telemetry.enabled`                 | Enable OpenTelemtry collector                                                                                            | `False` |
-| `telemetry.metrics.port`           | Prometheus port to send metrics                                                                                          | `8080` |
-| `telemetry.metrics.tracing.jaeger` | Jaeger endpoint to send traces                                                                                           |  ``|
-
-Check the `kubewarden-defaults` chart documentation to see the available PolicyServer configuration.
+For the default PolicyServer configuration, Check the `kubewarden-defaults`
+chart and its documentation.
 
 # Kubewarden usage
 

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -1,6 +1,6 @@
 # Settings for kubewarden-controller.
 
-# nameOverride Replaces the release name of the chart in `Chart.yaml` file when
+# nameOverride Replaces the release name of the chart in Chart.yaml file when
 # this is used to construct Kubernetes object names
 nameOverride: ""
 # fullnameOverride completely replaces the generated release name

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -33,7 +33,7 @@ preDeleteJob:
     repository: ""
     tag: "v1.23.3"
 
-# `kubewarden-controller` deployment settings:
+# kubewarden-controller deployment settings:
 podAnnotations: {}
 nodeSelector: {}
 tolerations: []

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -1,8 +1,15 @@
 # Settings for kubewarden-controller.
+
+# nameOverride Replaces the release name of the chart in `Chart.yaml` file when
+# this is used to construct Kubernetes object names
 nameOverride: ""
+# fullnameOverride completely replaces the generated release name
 fullnameOverride: ""
+
+# Secrets to pull container images from private registries
 imagePullSecrets: []
 
+# open-telemetry options
 telemetry:
   enabled: False
   metrics:
@@ -26,6 +33,7 @@ preDeleteJob:
     repository: ""
     tag: "v1.23.3"
 
+# `kubewarden-controller` deployment settings:
 podAnnotations: {}
 nodeSelector: {}
 tolerations: []

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -44,7 +44,7 @@ preDeleteJob:
     repository: ""
     tag: "v1.23.3"
 
-# `kubewarden-controller` deployment settings:
+# kubewarden-controller deployment settings:
 podAnnotations: {}
 nodeSelector: {}
 tolerations: []

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -11,7 +11,7 @@ common:
 
 # Settings for kubewarden-controller.
 
-# nameOverride Replaces the release name of the chart in `Chart.yaml` file when
+# nameOverride Replaces the release name of the chart in Chart.yaml file when
 # this is used to construct Kubernetes object names
 nameOverride: ""
 # fullnameOverride completely replaces the generated release name

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -10,10 +10,17 @@ common:
       enabled: true
 
 # Settings for kubewarden-controller.
+
+# nameOverride Replaces the release name of the chart in `Chart.yaml` file when
+# this is used to construct Kubernetes object names
 nameOverride: ""
+# fullnameOverride completely replaces the generated release name
 fullnameOverride: ""
+
+# Secrets to pull container images from private registries
 imagePullSecrets: []
 
+# open-telemetry options
 telemetry:
   enabled: False
   metrics:
@@ -37,6 +44,7 @@ preDeleteJob:
     repository: ""
     tag: "v1.23.3"
 
+# `kubewarden-controller` deployment settings:
 podAnnotations: {}
 nodeSelector: {}
 tolerations: []

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
+version: 1.1.6

--- a/charts/kubewarden-defaults/README.md
+++ b/charts/kubewarden-defaults/README.md
@@ -77,34 +77,4 @@ If you want to keep the history use `--keep-history` flag.
 
 ## Configuration
 
-The following tables list the configurable parameters of the `kubewarden-defaults`
-chart and their default values.
-
-| Parameter                                                          | Description                                                                                                              | Default             |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ | ------------------- |
-| `policyServer.replicaCount`                                        | Replica size for the `policy-server` deployment                                                                          | `1`                 |
-| `policyServer.image.repository`                                    | The `policy-server` container image to be used                                                                           | `ghcr.io/kubewarden/policy-server` |
-| `policyServer.image.tag`                                           | The tag of the `policy-server` container image to be used                                                                | ``                  |
-| `policyServer.telemetry.enabled`                                   | Enable OpenTelemetry configuration                                                                                       | `False`             |
-| `policyServer.imagePullSecret`                                     | Name of ImagePullSecret secret in the same namespace, used both for pulling the container images and the policies from OCI repositories. | `` |
-| `policyServer.insecureSources`                                     | List of insecure URIs to policy repositories.                                                                            | `[]`                |
-| `policyServer.sourceAuthorities`                                   | Registry URIs endpoints to a list of their associated PEM encoded certificate authorities that have to be used to verify the certificate used by the endpoint. | `{}` |
-| `recommendedPolicies.enabled`                                      | Install the recommended policies                                                                                         | `False`             |
-| `recommendedPolicies.skipNamespaces`                               | Recommended policies should ignore resources from these namespaces                                                       | `[calico-system, cattle-alerting, cattle-fleet-local-system, cattle-fleet-system, cattle-global-data, cattle-global-nt, cattle-impersonation-system, cattle-istio, cattle-logging, cattle-pipeline, cattle-prometheus, cattle-system, cert-manager, ingress-nginx, kube-node-lease, kube-public, kube-system, rancher-operator-system, security-scan, tigera-operator]` |
-| `recommendedPolicies.defaultPolicyMode`                            | The policy mode used in all default policies                                                                             | `monitor`           |
-| `recommendedPolicies.allowPrivilegeEscalationPolicy.module`        | Module used to deploy the `allow-privilege-escalation-psp` policy                                                        | `ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.1.11` |
-| `recommendedPolicies.allowPrivilegeEscalationPolicy.name`          | Name of the `allow-privilege-escalation-psp` policy                                                                      | `no-privilege-escalation` |
-| `recommendedPolicies.hostNamespacePolicy.module`                   | Module used to deploy the `host-namespaces-psp` policy                                                                   | `ghcr.io/kubewarden/policies/host-namespaces-psp:v0.1.2` |
-| `recommendedPolicies.hostNamespacePolicy.name`                     | Name of the `host-namespaces-psp-policy` policy                                                                          | `no-host-namespaces-sharing` |
-| `recommendedPolicies.podPrivilegedPolicy.module`                   | Module user to deploy the `pod-privileged` policy                                                                        | `ghcr.io/kubewarden/policies/pod-privileged:v0.2.1` |
-| `recommendedPolicies.podPrivilegedPolicy.name`                     | Name of the `pod-privileged` policy                                                                                      | `no-privileged-pod` |
-| `recommendedPolicies.userGroupPolicy.module`                       | Module used to deploy the `user-group-psp` policy                                                                        | `ghcr.io/kubewarden/policies/user-group-psp-policy:v0.2.0` |
-| `recommendedPolicies.userGroupPolicy.name`                         | Name of the `user-group-psp` policy                                                                                      | `do-not-run-as-root` |
-| `recommendedPolicies.hostPathsPolicy.module`                       | Module used to deploy `hostpaths-psp` policy                                                                             | `ghcr.io/kubewarden/policies/hostpaths-psp:v0.1.5` |
-| `recommendedPolicies.hostPathsPolicy.name`                         | Name of the `hostpaths-psp` policy                                                                                       | `do-not-share-hostpaths` |
-| `recommendedPolicies.hostPathsPolicy.paths`                        | Paths allowed to be accessed by containers                                                                               | `[{ pathPrefix: "/tmp", readOnly: true }]` |
-| `recommendedPolicies.capabilitiesPolicy.module`                    | Module used to deploy the `capabilities-psp` policy                                                                      | `ghcr.io/kubewarden/policies/capabilities-psp:v0.1.9`|
-| `recommendedPolicies.capabilitiesPolicy.name`                      | Name of the `capabilities-psp` policy                                                                                    | `"drop-capabilities"`|
-| `recommendedPolicies.capabilitiesPolicy.allowed_capabilities`      | Capabilities allowed to be added to a container                                                                          | `[]` |
-| `recommendedPolicies.capabilitiesPolicy.required_drop_capabilities`| Capabilities that must be dropped from containers                                                                        | `[ALL]`|
-| `recommendedPolicies.capabilitiesPolicy.default_add_capabilities`  | Capabilities added to containers by default                                                                              | `[]`|
+See the `values.yaml` file of the chart for the configuration values.


### PR DESCRIPTION
Merge "Configuration" sections of charts into their values.yaml, using values.yaml and its comments as canonical source for documentation that is DRY.