### PR TITLE
Fix capabilities values

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.6
+version: 1.1.7

--- a/charts/kubewarden-defaults/templates/capabilities-policy.yaml
+++ b/charts/kubewarden-defaults/templates/capabilities-policy.yaml
@@ -16,17 +16,22 @@ spec:
     - UPDATE
   mutating: true
   settings:
+{{- if .Values.recommendedPolicies.capabilitiesPolicy.allowed_capabilities }}
       allowed_capabilities:
-{{- range .Values.recommendedPolicies.capabilitiesPolicy.allowed_capabilities }}
+      {{- range .Values.recommendedPolicies.capabilitiesPolicy.allowed_capabilities }}
         - {{ . }}
+      {{- end }}
 {{- end }}
+{{- if .Values.recommendedPolicies.capabilitiesPolicy.required_drop_capabilities }}
       required_drop_capabilities:
-{{- range .Values.recommendedPolicies.capabilitiesPolicy.required_drop_capabilities }}
+      {{- range .Values.recommendedPolicies.capabilitiesPolicy.required_drop_capabilities }}
         - {{ . }}
+      {{- end }}
 {{- end }}
+{{- if .Values.recommendedPolicies.capabilitiesPolicy.default_add_capabilities }}
       default_add_capabilities:
-{{- range .Values.recommendedPolicies.capabilitiesPolicy.default_add_capabilities }}
+      {{- range .Values.recommendedPolicies.capabilitiesPolicy.default_add_capabilities }}
         - {{ . }}
+      {{- end }}
 {{- end }}
-
 {{ end }}


### PR DESCRIPTION
## Description

If no:

`.Values.recommendedPolicies.capabilitiesPolicy.allowed_capabilities`
`.Values.recommendedPolicies.capabilitiesPolicy.required_drop_capabilities`

are passed, then we get incorrect settings rendered such as:
```
  settings:
    allowed_capabilities: null
    default_add_capabilities: null
    required_drop_capabilities:
    - ALL
```

Skip rendering `settings.recommendedPolicies.capabilitiesPolicy` if their array is empty.

## Tests

`helm template charts/kubewarden-defaults --set recommendedPolicies.enabled=True`
which renders just `required_drop_capabilities: [ - ALL ]`,

and `helm template charts/kubewarden-defaults --values
capabilities-values.yml` with some settings, which renders those
settings correctly.
