### PR TITLE
feat!: Add Rancher integration for Rancher Explorer UI

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -4,6 +4,10 @@ description: A Helm chart for deploying the Kubewarden stack
 icon: https://www.kubewarden.io/images/icon-kubewarden.svg
 type: application
 kubeVersion: ">= 1.19.0"
+keywords:
+  - Security
+  - Infrastructure
+  - Monitoring
 home: https://www.kubewarden.io/
 maintainers:
 - name: Flavio Castelli

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -3,6 +3,7 @@ name: kubewarden-controller
 description: A Helm chart for deploying the Kubewarden stack
 icon: https://www.kubewarden.io/images/icon-kubewarden.svg
 type: application
+kubeVersion: ">= 1.19.0"
 home: https://www.kubewarden.io/
 maintainers:
 - name: Flavio Castelli

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -18,10 +18,10 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.2.0
 
 # This is the version of kubewarden-controller container image to be used
-appVersion: "v1.1.0"
+appVersion: "v1.2.0"
 
 annotations:
   # required ones:
@@ -33,7 +33,7 @@ annotations:
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
 
   # optional ones:
-  catalog.cattle.io/auto-install: kubewarden-crds=99.99.99 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
+  catalog.cattle.io/auto-install: kubewarden-crds=1.2.0 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
 
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
@@ -44,7 +44,7 @@ annotations:
   catalog.cattle.io/requests-memory: "50Mi"
 
   catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.6.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
-  catalog.cattle.io/upstream-version: "0.0.1"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.2.0"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -34,6 +34,7 @@ annotations:
 
   # optional ones:
   catalog.cattle.io/auto-install: kubewarden-crds=99.99.99 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
+  catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
 
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
 

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -31,3 +31,17 @@ annotations:
   catalog.cattle.io/ui-component: kubewarden # This is added for custom UI deployment of a chart
   catalog.cattle.io/display-name: Kubewarden-controller # Only for Charts with custom UI
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
+
+  # optional ones:
+  catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
+
+  # The following two will create a UI warning if the request is not available in cluster
+  # Assume the most standard setup for your chart. These can be strings with amounts, ie 64Mi or 2Gi are both valid.
+  catalog.cattle.io/requests-cpu: "250m"
+  catalog.cattle.io/requests-memory: "50Mi"
+
+  catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.6.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
+
+  # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
+  # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
+  catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -44,6 +44,7 @@ annotations:
   catalog.cattle.io/requests-memory: "50Mi"
 
   catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.6.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
+  catalog.cattle.io/upstream-version: "0.0.1"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -22,3 +22,12 @@ version: 1.1.1
 
 # This is the version of kubewarden-controller container image to be used
 appVersion: "v1.1.0"
+
+annotations:
+  # required ones:
+  catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
+  catalog.cattle.io/namespace: cattle-kubewarden-system # Must prefix with cattle- and suffix with -system
+  catalog.cattle.io/release-name: rancher-kubewarden-controller # If this is an upstream app, prefixing with rancher is the preferred naming choice.
+  catalog.cattle.io/ui-component: kubewarden # This is added for custom UI deployment of a chart
+  catalog.cattle.io/display-name: Kubewarden-controller # Only for Charts with custom UI
+  catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -33,6 +33,8 @@ annotations:
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
 
   # optional ones:
+  catalog.cattle.io/auto-install: kubewarden-crds=99.99.99 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
+
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
 
   # The following two will create a UI warning if the request is not available in cluster

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -20,17 +20,15 @@ telemetry:
       # Jaeger endpoint to send traces to
       # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:14250"
 image:
-  # controller image to be used. Leave empty to use
-  # ghcr.io/kubewarden/kubewarden-controller
-  repository: ""
-  # image tag, leave empty to use chart's AppVersion
-  tag: ""
+  # controller image to be used
+  repository: "ghcr.io/kubewarden/kubewarden-controller"
+  # image tag
+  tag: "v1.1.0"
 
 preDeleteJob:
   image:
-    # kubectl image to be used in the pre-delete helm hook. Leave empty to use
-    # ghcr.io/kubewarden/kubectl
-    repository: ""
+    # kubectl image to be used in the pre-delete helm hook
+    repository: "ghcr.io/kubewarden/kubectl"
     tag: "v1.23.3"
 
 # kubewarden-controller deployment settings:

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           - name: KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT
             value: "{{ .Values.telemetry.metrics.port | default 8080 }}"
         {{- end }}
-        image: '{{ .Values.image.repository | default "ghcr.io/kubewarden/kubewarden-controller" }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
+        image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:
           httpGet:

--- a/charts/kubewarden-controller/templates/pre-delete-hook.yaml
+++ b/charts/kubewarden-controller/templates/pre-delete-hook.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     "helm.sh/hook": pre-delete
@@ -25,5 +24,5 @@ spec:
       serviceAccountName: {{ include "kubewarden-controller.serviceAccountName" . }}
       containers:
         - name: pre-delete-job
-          image: '{{ .Values.preDeleteJob.image.repository | default "ghcr.io/kubewarden/kubectl" }}:{{ .Values.preDeleteJob.image.tag }}'
+          image: '{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
           command: ["kubectl", "delete", "--all", "policyservers.policies.kubewarden.io"]

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -31,17 +31,15 @@ telemetry:
       # Jaeger endpoint to send traces to
       # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:14250"
 image:
-  # controller image to be used. Leave empty to use
-  # ghcr.io/kubewarden/kubewarden-controller
-  repository: ""
-  # image tag, leave empty to use chart's AppVersion
-  tag: ""
+  # controller image to be used
+  repository: "ghcr.io/kubewarden/kubewarden-controller"
+  # image tag
+  tag: "v1.1.0"
 
 preDeleteJob:
   image:
-    # kubectl image to be used in the pre-delete helm hook. Leave empty to use
-    # ghcr.io/kubewarden/kubectl
-    repository: ""
+    # kubectl image to be used in the pre-delete helm hook
+    repository: "ghcr.io/kubewarden/kubectl"
     tag: "v1.23.3"
 
 # kubewarden-controller deployment settings:

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -3,6 +3,7 @@ name: kubewarden-crds
 description: A Helm chart for deploying the Kubewarden CRDs
 icon: https://www.kubewarden.io/images/icon-kubewarden.svg
 type: application
+kubeVersion: ">= 1.19.0"
 home: https://www.kubewarden.io/
 maintainers:
 - name: Flavio Castelli

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -16,6 +16,11 @@ maintainers:
   email: jguilhermevanz@suse.com
 - name: Raul Cabello Martin
   email: raul.cabello@suse.com
+keywords:
+  - Security
+  - Infrastructure
+  - Monitoring
+
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -34,6 +34,8 @@ annotations:
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
 
   # optional ones:
+  catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
+
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -25,3 +25,10 @@ keywords:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.1.0
+
+annotations:
+  # required ones:
+  catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
+  catalog.cattle.io/namespace: cattle-kubewarden-system # Must prefix with cattle- and suffix with -system
+  catalog.cattle.io/release-name: rancher-kubewarden-crds # If this is an upstream app, prefixing with rancher is the preferred naming choice.
+  catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -37,6 +37,8 @@ annotations:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
+  catalog.cattle.io/upstream-version: "0.0.1"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -24,7 +24,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 annotations:
   # required ones:
@@ -37,7 +37,7 @@ annotations:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
-  catalog.cattle.io/upstream-version: "0.0.1"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.2.0"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -32,3 +32,9 @@ annotations:
   catalog.cattle.io/namespace: cattle-kubewarden-system # Must prefix with cattle- and suffix with -system
   catalog.cattle.io/release-name: rancher-kubewarden-crds # If this is an upstream app, prefixing with rancher is the preferred naming choice.
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
+
+  # optional ones:
+  catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
+  # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
+  # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
+  catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -3,6 +3,7 @@ name: kubewarden-defaults
 description: A Helm chart for deploying Kubewarden's default PolicyServer instance
 icon: https://www.kubewarden.io/images/icon-kubewarden.svg
 type: application
+kubeVersion: ">= 1.19.0"
 home: https://www.kubewarden.io/
 maintainers:
 - name: José Guilherme Vanz

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -8,6 +8,10 @@ home: https://www.kubewarden.io/
 maintainers:
 - name: José Guilherme Vanz
   email: jguilhermevanz@suse.com
+keywords:
+  - Security
+  - Infrastructure
+  - Monitoring
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -31,6 +31,8 @@ annotations:
   catalog.cattle.io/requires-gvr: "policyservers.policies.kubewarden.io/v1" # This type MUST be visible to the user before they can install this chart.
 
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
+  catalog.cattle.io/upstream-version: "0.0.1"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -28,8 +28,6 @@ annotations:
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
 
   # optional ones:
-  catalog.cattle.io/requires-gvr: "policyservers.policies.kubewarden.io/v1" # This type MUST be visible to the user before they can install this chart.
-
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
   catalog.cattle.io/upstream-version: "1.2.0"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.7
+version: 1.2.0
 
 annotations:
   # required ones:
@@ -31,7 +31,7 @@ annotations:
   catalog.cattle.io/requires-gvr: "policyservers.policies.kubewarden.io/v1" # This type MUST be visible to the user before they can install this chart.
 
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
-  catalog.cattle.io/upstream-version: "0.0.1"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.2.0"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -26,3 +26,9 @@ annotations:
   catalog.cattle.io/ui-component: kubewarden # This is added for custom UI deployment of a chart
   catalog.cattle.io/display-name: Kubewarden-defaults # Only for Charts with custom UI
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
+
+  # optional ones:
+  catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
+  # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
+  # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
+  catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -17,3 +17,12 @@ keywords:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.1.7
+
+annotations:
+  # required ones:
+  catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
+  catalog.cattle.io/namespace: cattle-kubewarden-system # Must prefix with cattle- and suffix with -system
+  catalog.cattle.io/release-name: rancher-kubewarden-defaults # If this is an upstream app, prefixing with rancher is the preferred naming choice.
+  catalog.cattle.io/ui-component: kubewarden # This is added for custom UI deployment of a chart
+  catalog.cattle.io/display-name: Kubewarden-defaults # Only for Charts with custom UI
+  catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -28,6 +28,8 @@ annotations:
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
 
   # optional ones:
+  catalog.cattle.io/requires-gvr: "policyservers.policies.kubewarden.io/v1" # This type MUST be visible to the user before they can install this chart.
+
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
partial implementation of https://github.com/kubewarden/rfc/pull/11.

Missing:
- kubewarden-defaults hard-depend on controller. `requires-gvr` annot doesn't seem to work. Not important, as I suppose prior to inclusion in Rancher UI, we would mark all charts but `kubewarden-controller` as `hidden`, and use Kubewarden UI to install `kubewarden-defaults`.
- Changes to `kubewarden-defaults` to mirror wasm modules. This will not be possible until Rancher provides an OCI registry in addition to their Rancher DockerHub registry.

## Test

To test, install Rancher and then add the Kubewarden charts from the UI:


```shell
minikube start --kubernetes-version=v1.23.9
minikube addons enable ingress

kubectl create namespace cattle-system

kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cert-manager.crds.yaml

helm install --wait \
    cert-manager jetstack/cert-manager \
  --namespace cert-manager \
  --create-namespace \
  --version v1.7.1

helm install rancher rancher-latest/rancher \
  --namespace cattle-system \
  --set hostname=rancher.local \
  --set replicas=1 \
  --set bootstrapPassword=password

# 'rancher.local is in /etc/hosts matching the minikube ip'
```

With Rancher deployed,  install `kubewarden-controller` and then `kubewarden-defaults` from a GH repo in Rancher Explorer UI with: `https://github.com/kubewarden/helm-charts.git` and branch `rancher-1.1`.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement
