### PR TITLE
feat(Rancher): Hide `kubewarden-defaults`, show `kubewarden-controller` as `Kubewarden`

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -28,7 +28,7 @@ annotations:
   catalog.cattle.io/namespace: cattle-kubewarden-system # Must prefix with cattle- and suffix with -system
   catalog.cattle.io/release-name: rancher-kubewarden-controller # If this is an upstream app, prefixing with rancher is the preferred naming choice.
   catalog.cattle.io/ui-component: kubewarden # This is added for custom UI deployment of a chart
-  catalog.cattle.io/display-name: Kubewarden-controller # Only for Charts with custom UI
+  catalog.cattle.io/display-name: Kubewarden # Only for Charts with custom UI
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
 
   # optional ones:

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -29,6 +29,8 @@ annotations:
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
 
   # optional ones:
+  catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
+
   catalog.cattle.io/auto-install: kubewarden-crds=1.2.0 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
   catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
   catalog.cattle.io/upstream-version: "1.2.0"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
 Hide `kubewarden-defaults`, show `kubewarden-controller` as `Kubewarden`.

## Test

To test, install Rancher and then add the Kubewarden charts from the UI:


```shell
minikube start --kubernetes-version=v1.23.9
minikube addons enable ingress

kubectl create namespace cattle-system

kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cert-manager.crds.yaml

helm install --wait \
    cert-manager jetstack/cert-manager \
  --namespace cert-manager \
  --create-namespace \
  --version v1.7.1

helm install rancher rancher-latest/rancher \
  --namespace cattle-system \
  --set hostname=rancher.local \
  --set replicas=1 \
  --set bootstrapPassword=password

# 'rancher.local is in /etc/hosts matching the minikube ip'
```



## Additional Information

Don't delete branch, please. This is a feature branch containing all rancher-needed modifications.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
