### PR TITLE
Remove catalog.cattle.io/scope annotation

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2
+version: 1.2.3
 
 # This is the version of kubewarden-controller container image to be used
 appVersion: "v1.1.1"
@@ -32,7 +32,7 @@ annotations:
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
 
   # optional ones:
-  catalog.cattle.io/auto-install: kubewarden-crds=1.2.1 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
+  catalog.cattle.io/auto-install: kubewarden-crds=1.2.2 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
 
   # The following two will create a UI warning if the request is not available in cluster
@@ -41,7 +41,7 @@ annotations:
   catalog.cattle.io/requests-memory: "50Mi"
 
   catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.6.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
-  catalog.cattle.io/upstream-version: "1.2.2"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.2.3"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -35,8 +35,6 @@ annotations:
   catalog.cattle.io/auto-install: kubewarden-crds=1.2.1 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
 
-  catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
-
   # The following two will create a UI warning if the request is not available in cluster
   # Assume the most standard setup for your chart. These can be strings with amounts, ie 64Mi or 2Gi are both valid.
   catalog.cattle.io/requests-cpu: "250m"

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 
 annotations:
   # required ones:
@@ -29,7 +29,7 @@ annotations:
   # optional ones:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
-  catalog.cattle.io/upstream-version: "1.2.1"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.2.2"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -29,7 +29,6 @@ annotations:
   # optional ones:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
-  catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
   catalog.cattle.io/upstream-version: "1.2.1"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 
 annotations:
   # required ones:
@@ -31,8 +31,8 @@ annotations:
   # optional ones:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
-  catalog.cattle.io/auto-install: kubewarden-crds=1.2.1 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
-  catalog.cattle.io/upstream-version: "1.2.1"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/auto-install: kubewarden-crds=1.2.2 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
+  catalog.cattle.io/upstream-version: "1.2.2"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -32,7 +32,6 @@ annotations:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
   catalog.cattle.io/auto-install: kubewarden-crds=1.2.1 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
-  catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
   catalog.cattle.io/upstream-version: "1.2.1"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`


### PR DESCRIPTION
## Description

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
In order to list the `kubewarden-controller` chart on downstream clusters within Rancher, this annotation needs to be removed

## Additional Information
This annotation would only be necessary if we did not want to enable Kubewarden on downstream clusters.
