### PR TITLE
Create v1.3.0-rc1 release

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -17,10 +17,10 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.3
+version: 1.2.4
 
 # This is the version of kubewarden-controller container image to be used
-appVersion: "v1.1.1"
+appVersion: "v1.3.0-rc1"
 
 annotations:
   # required ones:


### PR DESCRIPTION
Tag a new release of the controller chart.

Given there were no changes to the CRDs and to the default deployment, the other two charts have not been touched.

