### PR TITLE
Revert "Update index.yaml"

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -16,41 +16,6 @@ entries:
       catalog.cattle.io/ui-component: kubewarden
       catalog.cattle.io/upstream-version: 1.2.3
     apiVersion: v2
-    appVersion: v1.3.0-rc1
-    created: "2022-10-24T13:37:25.004296379Z"
-    description: A Helm chart for deploying the Kubewarden stack
-    digest: 7e72df66bbf5d6011340603a81732b93e3831d3aa545e41ad5bf8f972225e599
-    home: https://www.kubewarden.io/
-    icon: https://www.kubewarden.io/images/icon-kubewarden.svg
-    keywords:
-    - Security
-    - Infrastructure
-    - Monitoring
-    kubeVersion: '>= 1.19.0'
-    maintainers:
-    - email: kubewarden@suse.de
-      name: Kubewarden Maintainers
-      url: https://github.com/orgs/kubewarden/teams/maintainers
-    name: kubewarden-controller
-    type: application
-    urls:
-    - https://github.com/kubewarden/helm-charts/releases/download/kubewarden-controller-1.2.4/kubewarden-controller-1.2.4.tgz
-    version: 1.2.4
-  - annotations:
-      catalog.cattle.io/auto-install: kubewarden-crds=1.2.2
-      catalog.cattle.io/certified: rancher
-      catalog.cattle.io/display-name: Kubewarden
-      catalog.cattle.io/namespace: cattle-kubewarden-system
-      catalog.cattle.io/os: linux
-      catalog.cattle.io/provides-gvr: policyservers.policies.kubewarden.io/v1
-      catalog.cattle.io/rancher-version: '>= 2.6.0-0 <= 2.6.100-0'
-      catalog.cattle.io/release-name: rancher-kubewarden-controller
-      catalog.cattle.io/requests-cpu: 250m
-      catalog.cattle.io/requests-memory: 50Mi
-      catalog.cattle.io/type: cluster-tool
-      catalog.cattle.io/ui-component: kubewarden
-      catalog.cattle.io/upstream-version: 1.2.3
-    apiVersion: v2
     appVersion: v1.1.1
     created: "2022-10-13T18:11:13.680714655Z"
     description: A Helm chart for deploying the Kubewarden stack
@@ -1643,4 +1608,4 @@ entries:
     urls:
     - https://github.com/kubewarden/helm-charts/releases/download/kubewarden-defaults-0.1.0/kubewarden-defaults-0.1.0.tgz
     version: 0.1.0
-generated: "2022-10-24T13:37:25.004767772Z"
+generated: "2022-10-13T18:11:13.950419204Z"


### PR DESCRIPTION
This is needed because the 1.2.4 release was flawed and we had to remove it.

This reverts commit 84f91de8f0331f87c8a784a920f00ba2a9ba355e.