### PR TITLE
Add back `kubewarden-controller` `1.2.4`, `kubewarden-defaults` `1.2.3`

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -14,6 +14,41 @@ entries:
       catalog.cattle.io/requests-memory: 50Mi
       catalog.cattle.io/type: cluster-tool
       catalog.cattle.io/ui-component: kubewarden
+      catalog.cattle.io/upstream-version: 1.2.4
+    apiVersion: v2
+    appVersion: v1.3.0
+    created: "2022-10-27T18:11:13.949932912Z"
+    description: A Helm chart for deploying the Kubewarden stack
+    digest: d9316db99d91457cda5bc3391f561474f103ab6742ada46ba66b5ed963423f65
+    home: https://www.kubewarden.io/
+    icon: https://www.kubewarden.io/images/icon-kubewarden.svg
+    keywords:
+    - Security
+    - Infrastructure
+    - Monitoring
+    kubeVersion: '>= 1.19.0'
+    maintainers:
+    - email: kubewarden@suse.de
+      name: Kubewarden Maintainers
+      url: https://github.com/orgs/kubewarden/teams/maintainers
+    name: kubewarden-controller
+    type: application
+    urls:
+    - https://github.com/kubewarden/helm-charts/releases/download/kubewarden-controller-1.2.4/kubewarden-controller-1.2.4.tgz
+    version: 1.2.4
+  - annotations:
+      catalog.cattle.io/auto-install: kubewarden-crds=1.2.2
+      catalog.cattle.io/certified: rancher
+      catalog.cattle.io/display-name: Kubewarden
+      catalog.cattle.io/namespace: cattle-kubewarden-system
+      catalog.cattle.io/os: linux
+      catalog.cattle.io/provides-gvr: policyservers.policies.kubewarden.io/v1
+      catalog.cattle.io/rancher-version: '>= 2.6.0-0 <= 2.6.100-0'
+      catalog.cattle.io/release-name: rancher-kubewarden-controller
+      catalog.cattle.io/requests-cpu: 250m
+      catalog.cattle.io/requests-memory: 50Mi
+      catalog.cattle.io/type: cluster-tool
+      catalog.cattle.io/ui-component: kubewarden
       catalog.cattle.io/upstream-version: 1.2.3
     apiVersion: v2
     appVersion: v1.1.1
@@ -1251,6 +1286,37 @@ entries:
     urls:
     - https://github.com/kubewarden/helm-charts/releases/download/kubewarden-defaults-1.2.4/kubewarden-defaults-1.2.4.tgz
     version: 1.2.4
+  - annotations:
+      catalog.cattle.io/auto-install: kubewarden-crds=1.2.2
+      catalog.cattle.io/certified: rancher
+      catalog.cattle.io/display-name: Kubewarden-defaults
+      catalog.cattle.io/hidden: "true"
+      catalog.cattle.io/namespace: cattle-kubewarden-system
+      catalog.cattle.io/os: linux
+      catalog.cattle.io/release-name: rancher-kubewarden-defaults
+      catalog.cattle.io/type: cluster-tool
+      catalog.cattle.io/ui-component: kubewarden
+      catalog.cattle.io/upstream-version: 1.2.3
+    apiVersion: v2
+    created: "2022-10-27T18:08:13.949932912Z"
+    description: A Helm chart for deploying Kubewarden's default PolicyServer instance
+    digest: a16c2ba83e012d8c06f94dcbe6a45b074dfb223274ffd41a00303987cd01ea40
+    home: https://www.kubewarden.io/
+    icon: https://www.kubewarden.io/images/icon-kubewarden.svg
+    keywords:
+    - Security
+    - Infrastructure
+    - Monitoring
+    kubeVersion: '>= 1.19.0'
+    maintainers:
+    - email: kubewarden@suse.de
+      name: Kubewarden Maintainers
+      url: https://github.com/orgs/kubewarden/teams/maintainers
+    name: kubewarden-defaults
+    type: application
+    urls:
+    - https://github.com/kubewarden/helm-charts/releases/download/kubewarden-defaults-1.2.3/kubewarden-defaults-1.2.3.tgz
+    version: 1.2.3
   - annotations:
       catalog.cattle.io/auto-install: kubewarden-crds=1.2.2
       catalog.cattle.io/certified: rancher

--- a/index.yaml
+++ b/index.yaml
@@ -1705,4 +1705,4 @@ entries:
     urls:
     - https://github.com/kubewarden/helm-charts/releases/download/kubewarden-defaults-0.1.0/kubewarden-defaults-0.1.0.tgz
     version: 0.1.0
-generated: "2022-11-07T14:37:11.389432841Z"
+generated: "2022-11-07T16:28:11.389432841Z"


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
This adds back `kubewarden-controller` `1.2.4`, `kubewarden-defaults` `1.2.3`. With correct digests pointing to the artifacts in the GH releases, and approximate `created` timestamps.

It bumps the index.yaml `generated` timestamp too.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Tested full Kubewarden installation with default policies active, by deploying from my fork, with:
```
helm repo add viccuad-kw https://raw.githubusercontent.com/viccuad/helm-charts/gh-pages/
vic@viccuad2 ~/suse/kw$ helm search repo viccuad-kw
NAME                                    CHART VERSION   APP VERSION     DESCRIPTION
viccuad-kw/kubewarden-controller        1.2.4           v1.3.0          A Helm chart for deploying the Kubewarden stack
viccuad-kw/kubewarden-crds              1.2.2                           A Helm chart for deploying the Kubewarden CRDs
viccuad-kw/kubewarden-defaults          1.2.4                           A Helm chart for deploying Kubewarden's default...
```

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

Release candidate versions are not present.
