### PR TITLE
Exclude longhorn-system namespace in recommended policies

### DIFF
--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -79,6 +79,7 @@ recommendedPolicies:
     - kube-node-lease
     - kube-public
     - kube-system
+    - longhorn-system
     - rancher-operator-system
     - security-scan
     - tigera-operator

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -93,6 +93,7 @@ recommendedPolicies:
     - kube-node-lease
     - kube-public
     - kube-system
+    - longhorn-system
     - rancher-operator-system
     - security-scan
     - tigera-operator


### PR DESCRIPTION
## Description

Adds `longhorn-system` to the recommended policies as an excluded namespace