### PR TITLE
Release to `kubewarden-controller-1.2.6`, `kubewarden-defaults-1.2.6`, fix `upstream-version`

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.5
+version: 1.2.6
 
 # This is the version of kubewarden-controller container image to be used
 appVersion: "v1.3.0"
@@ -41,7 +41,7 @@ annotations:
   catalog.cattle.io/requests-memory: "50Mi"
 
   catalog.cattle.io/rancher-version: ">= 2.7.0-0 <= 2.7.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
-  catalog.cattle.io/upstream-version: "1.2.5"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.2.6"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.5
+version: 1.2.6
 
 annotations:
   # required ones:
@@ -32,7 +32,7 @@ annotations:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
   catalog.cattle.io/auto-install: kubewarden-crds=1.2.2 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
-  catalog.cattle.io/upstream-version: "1.2.4"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.2.6"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
This triggers a new release of `kubewarden-controller-1.2.6`, `kubewarden-defaults-1.2.6`.

This release will include:
https://github.com/kubewarden/helm-charts/commit/0fd760bee79d51031c512f3572eb3e0fa1c2d800 
https://github.com/kubewarden/helm-charts/commit/d37495053ecc11f14d0db3de4f19ff3e51a1d039 (release job failed for this one in the past and it stayed unreleased).

Fix incorrect `upstream-version` for kubewarden-defaults chart.

## Additional info

Release job for `kubewarden-controller-1.2.5` failed in the past. With this PR I'm just bumping the patch version to trigger re-release from chart-releaser, instead of deleting tag, GH Release, and amending repo index.yaml.