### PR TITLE
fix: Declare compat with rancher 2.6

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -40,7 +40,7 @@ annotations:
   catalog.cattle.io/requests-cpu: "250m"
   catalog.cattle.io/requests-memory: "50Mi"
 
-  catalog.cattle.io/rancher-version: ">= 2.7.0-0 <= 2.7.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
+  catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.7.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
   catalog.cattle.io/upstream-version: "1.2.6"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`


### PR DESCRIPTION
## Description

fix: Declare compat with rancher 2.6
We mistakenly took it away.