### PR TITLE
fix: ensure charts can be installed on GKE

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -3,7 +3,7 @@ name: kubewarden-controller
 description: A Helm chart for deploying the Kubewarden stack
 icon: https://www.kubewarden.io/images/icon-kubewarden.svg
 type: application
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 keywords:
   - Security
   - Infrastructure
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.6
+version: 1.2.7
 
 # This is the version of kubewarden-controller container image to be used
 appVersion: "v1.3.0"
@@ -32,7 +32,7 @@ annotations:
   catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
 
   # optional ones:
-  catalog.cattle.io/auto-install: kubewarden-crds=1.2.2 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
+  catalog.cattle.io/auto-install: kubewarden-crds=1.2.3 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
 
   # The following two will create a UI warning if the request is not available in cluster
@@ -41,7 +41,7 @@ annotations:
   catalog.cattle.io/requests-memory: "50Mi"
 
   catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.7.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
-  catalog.cattle.io/upstream-version: "1.2.6"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.2.7"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -3,7 +3,7 @@ name: kubewarden-crds
 description: A Helm chart for deploying the Kubewarden CRDs
 icon: https://www.kubewarden.io/images/icon-kubewarden.svg
 type: application
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 home: https://www.kubewarden.io/
 maintainers:
 - name: Kubewarden Maintainers
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2
+version: 1.2.3
 
 annotations:
   # required ones:
@@ -29,7 +29,7 @@ annotations:
   # optional ones:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
-  catalog.cattle.io/upstream-version: "1.2.2"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.2.3"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -3,7 +3,7 @@ name: kubewarden-defaults
 description: A Helm chart for deploying Kubewarden's default PolicyServer instance
 icon: https://www.kubewarden.io/images/icon-kubewarden.svg
 type: application
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 home: https://www.kubewarden.io/
 maintainers:
 - name: Kubewarden Maintainers
@@ -17,7 +17,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.6
+version: 1.2.7
 
 annotations:
   # required ones:
@@ -31,8 +31,8 @@ annotations:
   # optional ones:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
-  catalog.cattle.io/auto-install: kubewarden-crds=1.2.2 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
-  catalog.cattle.io/upstream-version: "1.2.6"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/auto-install: kubewarden-crds=1.2.3 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
+  catalog.cattle.io/upstream-version: "1.2.7"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.


### PR DESCRIPTION
GKE clusters have a version number that embeds some GKE metadata. This metadata is added using the `-gke.<number>`.

Helm gets "confused" by this version and considers that a release candidate (due to semver rules).

Because of that, prior to this commit, attempting to deploy the Kubewarden stack on GKE resulted in this error:

```console
Error: INSTALLATION FAILED: chart requires kubeVersion: >= 1.19.0 which is incompatible with Kubernetes v1.23.8-gke.1900
```

This is now fixed
