### PR TITLE
fix: Push to ghcr without duplicating chart name

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -159,7 +159,7 @@ jobs:
             chart_name=$(helm show chart $chart | yq '.name' | sed 's/"//g')
             chart_version=$(helm show chart $chart | yq '.version' | sed 's/"//g')
             package_file=".cr-release-packages/$chart_name-$chart_version.tgz"
-            push_output=$(helm push $package_file "oci://$REGISTRY/charts/$chart_name")
+            push_output=$(helm push $package_file "oci://$REGISTRY/charts")
             chart_url=$(echo $push_output | sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\1\@\2/p')
             cosign sign "$chart_url"
           done


### PR DESCRIPTION
## Description

helm push expects `helm push <path_to_chart> <registry>`, not `<registry>/chart_name`.

Fixes overly long URIs for charts in ghcr:
https://github.com/kubewarden/helm-charts/pkgs/container/charts%2Fkubewarden-controller%2Fkubewarden-controller

## Test

Tested by running the shellscript locally.
<details>
  <summary>expand</summary>
  
```
$ bash foo.sh
+ chart_directory=release-packages
+ '[' '!' -d release-packages ']'
+ REGISTRY=ghcr.io/viccuad/test-charts
++ find release-packages -maxdepth 1 -mindepth 1 -type f
+ charts='release-packages/kubewarden-defaults-1.2.8.tgz
release-packages/kubewarden-crds-1.2.3.tgz
release-packages/kubewarden-controller-1.2.8.tgz'
+ for chart in $charts
++ helm show chart release-packages/kubewarden-defaults-1.2.8.tgz
++ yq .name
++ sed 's/"//g'
+ chart_name=kubewarden-defaults
++ helm show chart release-packages/kubewarden-defaults-1.2.8.tgz
++ yq .version
++ sed 's/"//g'
+ chart_version=1.2.8
+ package_file=release-packages/kubewarden-defaults-1.2.8.tgz
++ helm push release-packages/kubewarden-defaults-1.2.8.tgz oci://ghcr.io/viccuad/test-charts/charts
+ push_output='Pushed: ghcr.io/viccuad/test-charts/charts/kubewarden-defaults:1.2.8
Digest: sha256:ebb6d5bbe3ad23121546eefd2470421b30fb7c553eb064d066fa276cce822cea'
++ echo Pushed: ghcr.io/viccuad/test-charts/charts/kubewarden-defaults:1.2.8 Digest: sha256:ebb6d5bbe3ad23121546eefd2470421b30fb7c553eb064d066fa276cce822cea
++ sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\1\@\2/p'
+ chart_url=ghcr.io/viccuad/test-charts/charts/kubewarden-defaults@sha256:ebb6d5bbe3ad23121546eefd2470421b30fb7c553eb064d066fa276cce822cea
+ for chart in $charts
++ yq .name
++ helm show chart release-packages/kubewarden-crds-1.2.3.tgz
++ sed 's/"//g'
+ chart_name=kubewarden-crds
++ helm show chart release-packages/kubewarden-crds-1.2.3.tgz
++ yq .version
++ sed 's/"//g'
+ chart_version=1.2.3
+ package_file=release-packages/kubewarden-crds-1.2.3.tgz
++ helm push release-packages/kubewarden-crds-1.2.3.tgz oci://ghcr.io/viccuad/test-charts/charts
+ push_output='Pushed: ghcr.io/viccuad/test-charts/charts/kubewarden-crds:1.2.3
Digest: sha256:e885f550a9084f87d588035dbe5c62f4cb7106b1c7adaecd65045806972f0777'
++ echo Pushed: ghcr.io/viccuad/test-charts/charts/kubewarden-crds:1.2.3 Digest: sha256:e885f550a9084f87d588035dbe5c62f4cb7106b1c7adaecd65045806972f0777
++ sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\1\@\2/p'
+ chart_url=ghcr.io/viccuad/test-charts/charts/kubewarden-crds@sha256:e885f550a9084f87d588035dbe5c62f4cb7106b1c7adaecd65045806972f0777
+ for chart in $charts
++ helm show chart release-packages/kubewarden-controller-1.2.8.tgz
++ yq .name
++ sed 's/"//g'
+ chart_name=kubewarden-controller
++ helm show chart release-packages/kubewarden-controller-1.2.8.tgz
++ yq .version
++ sed 's/"//g'
+ chart_version=1.2.8
+ package_file=release-packages/kubewarden-controller-1.2.8.tgz
++ helm push release-packages/kubewarden-controller-1.2.8.tgz oci://ghcr.io/viccuad/test-charts/charts
+ push_output='Pushed: ghcr.io/viccuad/test-charts/charts/kubewarden-controller:1.2.8
Digest: sha256:03178179195d2514bf6c1165be542f517b4aa4dc50d93f93e5688068d9bb45a1'
++ echo Pushed: ghcr.io/viccuad/test-charts/charts/kubewarden-controller:1.2.8 Digest: sha256:03178179195d2514bf6c1165be542f517b4aa4dc50d93f93e5688068d9bb45a1
++ sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\1\@\2/p'
+ chart_url=ghcr.io/viccuad/test-charts/charts/kubewarden-controller@sha256:03178179195d2514bf6c1165be542f517b4aa4dc50d93f93e5688068d9bb45a1
```

</details>

Example: https://ghcr.io/viccuad/test-charts/charts/kubewarden-controller

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
