### PR TITLE
Release kubewarden-controller, kubewarden-defaults `1.3.0`

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.8
+version: 1.3.0
 
 # This is the version of Kubewarden stack
 appVersion: "v1.4.0"
@@ -44,7 +44,7 @@ annotations:
   catalog.cattle.io/requests-memory: "50Mi"
 
   catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.7.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
-  catalog.cattle.io/upstream-version: "1.2.8"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.3.0"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-controller/app-readme.md
+++ b/charts/kubewarden-controller/app-readme.md
@@ -4,6 +4,6 @@
 
 It is powered by [WebAssembly](https://webassembly.org/), so Kubewarden policies are architecture and operating system agnostic.
 
-Discover many policies contributed and maintained by the community in the [Policy hub](https://hub.kubewarden.io/).
+Discover many policies contributed and maintained by the community in [ArtifactHub](https://artifacthub.io/).
 
 Download policies or build your own once, and run it everywhere, no matter what the system is.

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -13,6 +13,10 @@ imagePullSecrets: []
 additionalLabels: {}
   # app: kubewarden-controller
 
+# -- Additional annotations to add to all resources
+additionalAnnotations: {}
+  # owner: IT-group1
+
 # open-telemetry options
 telemetry:
   enabled: False

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -34,7 +34,7 @@ image:
   # controller image to be used
   repository: "kubewarden/kubewarden-controller"
   # image tag
-  tag: "v1.4.0"
+  tag: "v1.4.1"
 
 preDeleteJob:
   image:

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -41,6 +41,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/component: controller
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: kubewarden
 {{- if .Values.additionalLabels }}
 {{ toYaml .Values.additionalLabels }}
 {{- end }}

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -56,6 +56,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Annotations
+*/}}
+{{- define "kubewarden-controller.annotations" -}}
+{{- if .Values.additionalAnnotations }}
+{{ toYaml .Values.additionalAnnotations }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "kubewarden-controller.serviceAccountName" -}}

--- a/charts/kubewarden-controller/templates/cert-tls.yaml
+++ b/charts/kubewarden-controller/templates/cert-tls.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 spec:
   dnsNames:
   - {{ include "kubewarden-controller.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc

--- a/charts/kubewarden-controller/templates/configmap.yaml
+++ b/charts/kubewarden-controller/templates/configmap.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 data:
   controller_manager_config.yaml: |
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- end }}
         {{- include "kubewarden-controller.annotations" . | nindent 8 }}
       labels:
-        {{- include "kubewarden-controller.selectorLabels" . | nindent 8 }}
+        {{- include "kubewarden-controller.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -19,6 +21,7 @@ spec:
         {{- if .Values.telemetry.enabled }}
         "sidecar.opentelemetry.io/inject": "true"
         {{- end }}
+        {{- include "kubewarden-controller.annotations" . | nindent 8 }}
       labels:
         {{- include "kubewarden-controller.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
+++ b/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 spec:
   mode: sidecar
   config: |

--- a/charts/kubewarden-controller/templates/pre-delete-hook.yaml
+++ b/charts/kubewarden-controller/templates/pre-delete-hook.yaml
@@ -11,6 +11,7 @@ metadata:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 spec:
   template:
     metadata:
@@ -19,6 +20,8 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+        {{- include "kubewarden-controller.annotations" . | nindent 8 }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ include "kubewarden-controller.serviceAccountName" . }}

--- a/charts/kubewarden-controller/templates/rbac.yaml
+++ b/charts/kubewarden-controller/templates/rbac.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""
@@ -45,6 +47,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""
@@ -88,6 +92,8 @@ metadata:
   name: kubewarden-controller-manager-cluster-role
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - admissionregistration.k8s.io
@@ -137,6 +143,8 @@ metadata:
   name: kubewarden-controller-manager-role
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - policies.kubewarden.io
@@ -200,6 +208,8 @@ metadata:
   name: kubewarden-controller-metrics-reader
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics
@@ -212,6 +222,8 @@ metadata:
   name: kubewarden-controller-proxy-role
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -233,6 +245,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -249,6 +263,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -264,6 +280,8 @@ metadata:
   name: kubewarden-controller-manager-cluster-role
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -279,6 +297,8 @@ metadata:
   name: kubewarden-controller-manager-rolebinding
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -294,6 +314,8 @@ metadata:
   name: kubewarden-controller-proxy-rolebinding
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kubewarden-controller/templates/service.yaml
+++ b/charts/kubewarden-controller/templates/service.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 spec:
   ports:
   {{- if .Values.telemetry.enabled }}
@@ -26,6 +28,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 spec:
   ports:
   - port: 443

--- a/charts/kubewarden-controller/templates/serviceaccount.yaml
+++ b/charts/kubewarden-controller/templates/serviceaccount.yaml
@@ -5,3 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}

--- a/charts/kubewarden-controller/templates/webhooks.yaml
+++ b/charts/kubewarden-controller/templates/webhooks.yaml
@@ -4,6 +4,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kubewarden-controller.fullname" . }}-serving-cert
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
   name: kubewarden-controller-mutating-webhook-configuration
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
@@ -78,6 +79,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kubewarden-controller.fullname" . }}-serving-cert
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
   name: kubewarden-controller-validating-webhook-configuration
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -25,6 +25,10 @@ imagePullSecrets: []
 additionalLabels: {}
   # app: kubewarden-controller
 
+# -- Additional annotations to add to all resources
+additionalAnnotations: {}
+  # owner: IT-group1
+
 # open-telemetry options
 telemetry:
   enabled: False

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -46,7 +46,7 @@ image:
   # controller image to be used
   repository: "kubewarden/kubewarden-controller"
   # image tag
-  tag: "v1.4.0"
+  tag: "v1.4.1"
 
 preDeleteJob:
   image:

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -20,7 +20,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.8
+version: 1.3.0
 
 annotations:
   # required ones:
@@ -35,7 +35,7 @@ annotations:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
   catalog.cattle.io/auto-install: kubewarden-crds=1.2.3 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
-  catalog.cattle.io/upstream-version: "1.2.8"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.3.0"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-defaults/app-readme.md
+++ b/charts/kubewarden-defaults/app-readme.md
@@ -4,6 +4,6 @@
 
 It is powered by [WebAssembly](https://webassembly.org/), so Kubewarden policies are architecture and operating system agnostic.
 
-Discover many policies contributed and maintained by the community in the [Policy hub](https://hub.kubewarden.io/).
+Discover many policies contributed and maintained by the community in [ArtifactHub](https://artifacthub.io/).
 
 Download policies or build your own once, and run it everywhere, no matter what the system is.

--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -2,6 +2,10 @@
 additionalLabels: {}
   # app: kubewarden-defaults
 
+# -- Additional annotations to add to all resources
+additionalAnnotations: {}
+  # owner: IT-group1
+
 # Policy Server settings
 policyServer:
   replicaCount: 1

--- a/charts/kubewarden-defaults/templates/_helpers.tpl
+++ b/charts/kubewarden-defaults/templates/_helpers.tpl
@@ -23,6 +23,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: kubewarden
 app.kubernetes.io/name: {{ include "kubewarden-defaults.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.additionalLabels }}

--- a/charts/kubewarden-defaults/templates/_helpers.tpl
+++ b/charts/kubewarden-defaults/templates/_helpers.tpl
@@ -17,6 +17,7 @@ Common labels
 */}}
 {{- define "kubewarden-defaults.labels" -}}
 helm.sh/chart: {{ include "kubewarden-defaults.chart" . }}
+{{ include "kubewarden-defaults.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- else }}
@@ -24,11 +25,17 @@ app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: kubewarden
-app.kubernetes.io/name: {{ include "kubewarden-defaults.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.additionalLabels }}
 {{ toYaml .Values.additionalLabels }}
 {{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubewarden-defaults.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubewarden-defaults.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*

--- a/charts/kubewarden-defaults/templates/_helpers.tpl
+++ b/charts/kubewarden-defaults/templates/_helpers.tpl
@@ -31,6 +31,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
+{{/*
+Annotations
+*/}}
+{{- define "kubewarden-defaults.annotations" -}}
+{{- if .Values.additionalAnnotations }}
+{{ toYaml .Values.additionalAnnotations }}
+{{- end }}
+{{- end }}
+
 {{- define "policy-namespace-selector" -}}
 namespaceSelector:
   matchExpressions:

--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}

--- a/charts/kubewarden-defaults/templates/capabilities-policy.yaml
+++ b/charts/kubewarden-defaults/templates/capabilities-policy.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.capabilitiesPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}

--- a/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.hostNamespacePolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}

--- a/charts/kubewarden-defaults/templates/host-path-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-path-policy.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.hostPathsPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}

--- a/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
+++ b/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.podPrivilegedPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}

--- a/charts/kubewarden-defaults/templates/policy-server-rbac.yaml
+++ b/charts/kubewarden-defaults/templates/policy-server-rbac.yaml
@@ -4,6 +4,8 @@ metadata:
   labels:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy-server
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ .Values.policyServer.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 ---
@@ -13,6 +15,8 @@ metadata:
   labels:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy-server
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: kubewarden-context-watcher
 rules:
 {{- range .Values.policyServer.permissions }}
@@ -30,6 +34,8 @@ metadata:
   labels:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy-server
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: kubewarden-context-watcher
 subjects:
 - kind: ServiceAccount

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -24,7 +24,6 @@ spec:
     {{- range $key, $value := .Values.policyServer.annotations }}
       {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
-    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   {{- if or .Values.policyServer.env .Values.policyServer.telemetry.enabled }}
   env:
     {{- if .Values.policyServer.telemetry.enabled }}

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy-server
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ .Values.common.policyServer.default.name }}
   finalizers:
     - kubewarden
@@ -22,6 +24,7 @@ spec:
     {{- range $key, $value := .Values.policyServer.annotations }}
       {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   {{- if or .Values.policyServer.env .Values.policyServer.telemetry.enabled }}
   env:
     {{- if .Values.policyServer.telemetry.enabled }}

--- a/charts/kubewarden-defaults/templates/user-group-policy.yaml
+++ b/charts/kubewarden-defaults/templates/user-group-policy.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "kubewarden-defaults.labels" . | nindent 4 }}
     app.kubernetes.io/component: policy
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.userGroupPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -14,6 +14,10 @@ common:
 additionalLabels: {}
   # app: kubewarden-defaults
 
+# -- Additional annotations to add to all resources
+additionalAnnotations: {}
+  # owner: IT-group1
+
 # Policy Server settings
 policyServer:
   replicaCount: 1


### PR DESCRIPTION
## Description


- feat: `.Values.additionalLabels`, set default recommended labels, thanks to https://github.com/kubewarden/helm-charts/pull/176
- feat: `.Values.additionalAnnotations`
- fix: Bump controller image to `v1.4.1`: maintenance dependency bumps. The maintenance dependency bumps make the controller image pass with A image scans (even if vulnerabilities of the previous image were not affecting us).

Fix https://github.com/kubewarden/helm-charts/issues/177

## Test


## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
