### PR TITLE
feat: Add questions.yaml to kubewarden-defaults chart

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -20,7 +20,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.4.0
 
 annotations:
   # required ones:
@@ -35,7 +35,7 @@ annotations:
   catalog.cattle.io/hidden: true  # Hide specific charts. Only use on CRD charts.
 
   catalog.cattle.io/auto-install: kubewarden-crds=1.2.3 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
-  catalog.cattle.io/upstream-version: "1.3.0"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.4.0"  # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
 
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -100,10 +100,10 @@ recommendedPolicies:
     module: "kubewarden/policies/host-namespaces-psp:v0.1.2"
     name: "no-host-namespace-sharing"
   podPrivilegedPolicy:
-    module: "kubewarden/policies/pod-privileged:v0.2.1"
+    module: "kubewarden/policies/pod-privileged:v0.2.2"
     name: "no-privileged-pod"
   userGroupPolicy:
-    module: "kubewarden/policies/user-group-psp:v0.2.0"
+    module: "kubewarden/policies/user-group-psp:v0.4.0"
     name: "do-not-run-as-root"
   hostPathsPolicy:
     module: "kubewarden/policies/hostpaths-psp:v0.1.5"

--- a/charts/kubewarden-defaults/questions.yaml
+++ b/charts/kubewarden-defaults/questions.yaml
@@ -1,0 +1,27 @@
+# This is a Rancher questions file
+---
+questions:
+# Recommended policies questions:
+- variable: "recommendedPolicies.enabled"
+  type: boolean
+  default: false
+  required: true
+  label: Enable recommended policies
+  description: |
+    Whether the recommended policies are enabled or not. Recommended
+    policies are a minimum set of policies that secure your cluster and
+    Kubewarden, while leaving the system namespaces untouched.
+  group: Settings
+- variable: "recommendedPolicies.defaultPolicyMode"
+  type: enum
+  options:
+    - "monitor"
+    - "protect"
+  default: "monitor"
+  show_if: recommendedPolicies.enabled=true
+  label: Execution mode of the recommended policies
+  description: |
+    Execution mode of the recommended policies. "protect" will reject requests,
+    "monitor" will log them. Transitioning from "monitor" to "protect" is
+    allowed, but not from "protect" to "monitor".
+  group: Settings

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -112,10 +112,10 @@ recommendedPolicies:
     module: "kubewarden/policies/host-namespaces-psp:v0.1.2"
     name: "no-host-namespace-sharing"
   podPrivilegedPolicy:
-    module: "kubewarden/policies/pod-privileged:v0.2.1"
+    module: "kubewarden/policies/pod-privileged:v0.2.2"
     name: "no-privileged-pod"
   userGroupPolicy:
-    module: "kubewarden/policies/user-group-psp:v0.2.0"
+    module: "kubewarden/policies/user-group-psp:v0.4.0"
     name: "do-not-run-as-root"
   hostPathsPolicy:
     module: "kubewarden/policies/hostpaths-psp:v0.1.5"


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/helm-charts/issues/172

Add questions.yaml for kubewarden-defaults.
Bump recommended policies tags.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

![questions](https://user-images.githubusercontent.com/2196685/211799800-e8d3baf3-786d-44e6-aead-564aec4c3230.png)



## Test

Tested by disabling the hidden annot, and deploying the kubewarden-defaults chart/app manually (out of Kubewarden UI). These questions will show up on Kubewarden UI also.
Bumped policies are also working.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

I intended to also add questions for the registry, repository and tag of the policy-server image, or at least the registry for the policy-server and policies, for air-gap use. But given that includes at least the sourcesAuthorities which are not trivial, I discarded the though to not confuse new users.
