### PR TITLE
fix: updates kubewarden-defaults when we have a new CRD version.

### DIFF
--- a/updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml
@@ -7,6 +7,12 @@ sources:
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "version"
+  defaultsChart:
+    name: Load chart version
+    kind: yaml
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "version"
   controllerChartValuesFile:
     kind: yaml
     spec:
@@ -17,7 +23,7 @@ sources:
     spec:
       file: "charts/kubewarden-controller/values.yaml"
       key: "image.tag"
-  defaultsChartVersion:
+  crdChartVersion:
     kind: yaml
     transformers:
       - semverinc: "patch"
@@ -27,12 +33,13 @@ sources:
 
 targets:
   installCRD:
-    name: "Install policy server CRD"
+    name: "Updates CRDs"
     kind: shell
     scmid: "default"
     disablesourceinput: true
     spec:
       command: bash updatecli/scripts/install_crds.sh
+
   updateChartValuesFile:
     name: "Update container image in the chart-values.yaml file"
     kind: yaml
@@ -42,6 +49,7 @@ targets:
       file: "charts/kubewarden-controller/chart-values.yaml"
       key: "image.tag"
       value: '{{ requiredEnv .releaseVersion }}'
+
   updateValuesFile:
     kind: yaml
     name: "Update container image in the values.yaml file"
@@ -51,6 +59,7 @@ targets:
       file: "charts/kubewarden-controller/values.yaml"
       key: "image.tag"
       value: '{{ requiredEnv .releaseVersion }}'
+
   chartPatchVersionUpdate:
     name: Bump chart patch version
     kind: yaml
@@ -61,6 +70,7 @@ targets:
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "version"
+
   chartPatchVersionUpdate2:
     name: Bump chart patch version in annotations
     kind: yaml
@@ -71,37 +81,61 @@ targets:
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: 'annotations.catalog\.cattle\.io/upstream-version'
-  updateDefaultsAutoInstallAnnotation:
+
+  updateControllerAutoInstallAnnotation:
     name: "Update kubewarden-controller auto-install annotation"
     kind: yaml
-    sourceid: defaultsChartVersion
+    sourceid: crdChartVersion
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: 'annotations.catalog\.cattle\.io/auto-install'
-      value: 'kubewarden-crds={{ source "defaultsChartVersion" }}'
-  updateDefaultsUpstreamVersionAnnotation:
+      value: 'kubewarden-crds={{ source "crdChartVersion" }}'
+
+  updateDefautlsAutoInstallAnnotation:
+    name: "Update kubewarden-defaults auto-install annotation"
+    kind: yaml
+    sourceid: crdChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: 'annotations.catalog\.cattle\.io/auto-install'
+      value: 'kubewarden-crds={{ source "crdChartVersion" }}'
+
+  chartDefaultsPatchVersionUpdate:
+    name: Bump chart patch version
+    kind: yaml
+    sourceid: defaultsChart
+    scmid: "default"
+    transformers:
+      - semverinc: "patch"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "version"
+
+  updateCRDUpstreamVersionAnnotation:
     name: "Update kubewarden-crds upstream-version annotation"
     kind: yaml
-    sourceid: defaultsChartVersion
+    sourceid: crdChartVersion
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-crds/Chart.yaml"
       key: 'annotations.catalog\.cattle\.io/upstream-version'
-      value: '{{ source "defaultsChartVersion" }}'
-  updateDefaultsChartPatchVersion:
+      value: '{{ source "crdChartVersion" }}'
+
+  updateCRDChartPatchVersion:
     name: "Update kubewarden-crds version"
     kind: yaml
-    sourceid: defaultsChartVersion
+    sourceid: crdChartVersion
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-crds/Chart.yaml"
       key: 'version'
-      value: '{{ source "defaultsChartVersion" }}'
+      value: '{{ source "crdChartVersion" }}'
 
 actions:
   createUpdatePR:
-    title: "Create PR to update Helm charts"
+    title: "Patch update Helm charts"
     helm-charts:
     kind: "github/pullrequest"
     scmid: "default"
@@ -112,10 +146,10 @@ actions:
         Automatic Helm chart update.
         This PR has been created by the automation used to automatically update the Helm charts when some Kubewarden component is released
 
-        REMEMBER TO SQUASH THE COMMIT BEFORE MERGING THIS PR!
+        REMEMBER IF YOU WANT TO MERGE IN A SINGLE COMMIT CHANGES AND VERSION BUMP, YOU MUST SQUASH THE COMMIT BEFORE MERGING THIS PR!
       draft: false
       labels:
-        - "kind/enhancement"
+        - "kind/fix"
 
 scms:
   default:

--- a/updatecli/updatecli.d/patch-kubewarden-controller.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-controller.yaml
@@ -74,7 +74,7 @@ actions:
         REMEMBER TO SQUASH THE COMMIT BEFORE MERGING THIS PR!
       draft: false
       labels:
-        - "kind/enhancement"
+        - "kind/fix"
 
 scms:
   default:

--- a/updatecli/updatecli.d/patch-kubewarden-defaults.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-defaults.yaml
@@ -75,7 +75,7 @@ actions:
         REMEMBER TO SQUASH THE COMMIT BEFORE MERGING THIS PR!
       draft: false
       labels:
-        - "kind/enhancement"
+        - "kind/fix"
 
 scms:
   default:


### PR DESCRIPTION
## Description

Updates the script used to patch release the Kubewarden charts to update the kubewarden-defaults chart annotations when a new kubewarden-crds chart is released.


