### PR TITLE
Update chart releaser action used to v1.5.0

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -74,7 +74,7 @@ jobs:
           make generate-policies-file
 
       - name: Run chart-releaser
-        uses: jvanz/chart-releaser-action@main
+        uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_dir: charts
         env:


### PR DESCRIPTION
## Description

Updates the version and repository of the Helm chart releaser action to the official v1.5.0. A fork as in use because it has a fix needed by the project. As the same fix is released in the official version, the CI can use the official release again.