### PR TITLE
Policy Server security configuration.

### DIFF
--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -62,6 +62,24 @@ policyServer:
   #     certs:
   #       - "cert4"
   sourceAuthorities:
+  #The following section can be used to configure the securityContext of the
+  #policy server workloads. The pod configuration allows any field defined in the PodSecurityContext kind.
+  #And the `container` configuration allows any field defined in the SecurityContext kind.
+  #See the allowed fielad at:
+  #https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podsecuritycontext-v1-core
+  #https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
+  #securityContexts:
+  #  pod:
+  #    runAsNonRoot: true
+  #  container:
+  #    readOnlyRootFilesystem: true
+  #    privileged: false
+  #    runAsNonRoot: true
+  #    allowPrivilegeEscalation: false
+  #    capabilities:
+  #      drop:
+  #        - "all"
+
 crdVersion: "policies.kubewarden.io/v1"
 recommendedPolicies:
   enabled: False

--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -42,9 +42,9 @@ policyServer:
   # insecureSources stores a list of allowed insecure registries.
   #
   # Example of usage:
-  #insecureSources:
-  #  - "source1"
-  #  - "source2"
+  # insecureSources:
+  #   - "source1"
+  #   - "source2"
   insecureSources:
   # sourceAuthorities is a list of the URIs and their PEM encoded certificates
   # used to authenticate them
@@ -62,23 +62,25 @@ policyServer:
   #     certs:
   #       - "cert4"
   sourceAuthorities:
-  #The following section can be used to configure the securityContext of the
-  #policy server workloads. The pod configuration allows any field defined in the PodSecurityContext kind.
-  #And the `container` configuration allows any field defined in the SecurityContext kind.
-  #See the allowed fielad at:
-  #https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podsecuritycontext-v1-core
-  #https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
-  #securityContexts:
-  #  pod:
-  #    runAsNonRoot: true
-  #  container:
-  #    readOnlyRootFilesystem: true
-  #    privileged: false
-  #    runAsNonRoot: true
-  #    allowPrivilegeEscalation: false
-  #    capabilities:
-  #      drop:
-  #        - "all"
+  # The following section can be used to configure the securityContext of the
+  # policy server workloads. The pod configuration allows any field defined in the PodSecurityContext kind.
+  # And the `container` configuration allows any field defined in the SecurityContext kind.
+  # See the allowed fielad at:
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podsecuritycontext-v1-core
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
+  #
+  # Example of usage:
+  # securityContexts:
+  #   pod:
+  #     runAsNonRoot: true
+  #   container:
+  #     readOnlyRootFilesystem: true
+  #     privileged: false
+  #     runAsNonRoot: true
+  #     allowPrivilegeEscalation: false
+  #     capabilities:
+  #       drop:
+  #         - "all"
 
 crdVersion: "policies.kubewarden.io/v1"
 recommendedPolicies:

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -38,6 +38,10 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+  {{- if .Values.policyServer.security }}
+  security:
+{{ toYaml .Values.policyServer.security | indent 4 }}
+  {{- end }}
   {{- if .Values.policyServer.imagePullSecret }}
   imagePullSecret: {{ .Values.policyServer.imagePullSecret | quote }}
   {{- end }}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -54,9 +54,9 @@ policyServer:
   # insecureSources stores a list of allowed insecure registries.
   #
   # Example of usage:
-  #insecureSources:
-  #  - "source1"
-  #  - "source2"
+  # insecureSources:
+  #   - "source1"
+  #   - "source2"
   insecureSources:
   # sourceAuthorities is a list of the URIs and their PEM encoded certificates
   # used to authenticate them
@@ -74,23 +74,25 @@ policyServer:
   #     certs:
   #       - "cert4"
   sourceAuthorities:
-  #The following section can be used to configure the securityContext of the
-  #policy server workloads. The pod configuration allows any field defined in the PodSecurityContext kind.
-  #And the `container` configuration allows any field defined in the SecurityContext kind.
-  #See the allowed fielad at:
-  #https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podsecuritycontext-v1-core
-  #https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
-  #securityContexts:
-  #  pod:
-  #    runAsNonRoot: true
-  #  container:
-  #    readOnlyRootFilesystem: true
-  #    privileged: false
-  #    runAsNonRoot: true
-  #    allowPrivilegeEscalation: false
-  #    capabilities:
-  #      drop:
-  #        - "all"
+  # The following section can be used to configure the securityContext of the
+  # policy server workloads. The pod configuration allows any field defined in the PodSecurityContext kind.
+  # And the `container` configuration allows any field defined in the SecurityContext kind.
+  # See the allowed fielad at:
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podsecuritycontext-v1-core
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
+  #
+  # Example of usage:
+  # securityContexts:
+  #   pod:
+  #     runAsNonRoot: true
+  #   container:
+  #     readOnlyRootFilesystem: true
+  #     privileged: false
+  #     runAsNonRoot: true
+  #     allowPrivilegeEscalation: false
+  #     capabilities:
+  #       drop:
+  #         - "all"
 
 crdVersion: "policies.kubewarden.io/v1"
 recommendedPolicies:

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -74,6 +74,24 @@ policyServer:
   #     certs:
   #       - "cert4"
   sourceAuthorities:
+  #The following section can be used to configure the securityContext of the
+  #policy server workloads. The pod configuration allows any field defined in the PodSecurityContext kind.
+  #And the `container` configuration allows any field defined in the SecurityContext kind.
+  #See the allowed fielad at:
+  #https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podsecuritycontext-v1-core
+  #https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
+  #securityContexts:
+  #  pod:
+  #    runAsNonRoot: true
+  #  container:
+  #    readOnlyRootFilesystem: true
+  #    privileged: false
+  #    runAsNonRoot: true
+  #    allowPrivilegeEscalation: false
+  #    capabilities:
+  #      drop:
+  #        - "all"
+
 crdVersion: "policies.kubewarden.io/v1"
 recommendedPolicies:
   enabled: False


### PR DESCRIPTION
## Description

Updates the Helm chart to make use of the latest changes in the policy server CRDs allowing users to define the "securityContext" of the workload. Therefore, this change allows users to customize the policy server "securityContext" changing the values of the Helm chart.

Fix PR makes use of the changes in the [controller](https://github.com/kubewarden/kubewarden-controller/pull/385)

Fix #191 
