### PR TITLE
fix: handle new monitoring namespace

### DIFF
--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -75,10 +75,11 @@ recommendedPolicies:
     - cattle-impersonation-system
     - cattle-istio
     - cattle-logging
+    - cattle-monitoring-system
+    - cattle-neuvector-system
     - cattle-pipeline
     - cattle-prometheus
     - cattle-system
-    - cattle-neuvector-system
     - cert-manager
     - ingress-nginx
     - kube-node-lease

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -87,10 +87,11 @@ recommendedPolicies:
     - cattle-impersonation-system
     - cattle-istio
     - cattle-logging
+    - cattle-monitoring-system
+    - cattle-neuvector-system
     - cattle-pipeline
     - cattle-prometheus
     - cattle-system
-    - cattle-neuvector-system
     - cert-manager
     - ingress-nginx
     - kube-node-lease


### PR DESCRIPTION
Rancher v2 monitoring is deployed under the `cattle-monitoring-system` namespace.

Add this namespace to the ignore list.
