### PR TITLE
Downgrade updatecli.

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -108,7 +108,7 @@ jobs:
           echo "must_update_crds_chart=$?" >> $GITHUB_OUTPUT
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v2
+        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c #v2.16.2
 
       - name: Update kubewarden-defaults Helm chart
         if: endsWith(github.event.client_payload.repository, 'policy-server')


### PR DESCRIPTION
## Description

Downgrades updatecli version used to avoid a bug which is preventing Helm charts to be released.

This PR is a reaction for this [failing](https://github.com/kubewarden/helm-charts/actions/runs/4144658093/jobs/7167992382)