### PR TITLE
Downgrade updatecli to v2.19.0

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -108,7 +108,7 @@ jobs:
           echo "must_update_crds_chart=$?" >> $GITHUB_OUTPUT
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c #v2.16.2
+        uses: updatecli/updatecli-action@v2
 
       - name: Update kubewarden-defaults Helm chart
         if: endsWith(github.event.client_payload.repository, 'policy-server')

--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -108,7 +108,7 @@ jobs:
           echo "must_update_crds_chart=$?" >> $GITHUB_OUTPUT
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v2
+        uses: updatecli/updatecli-action@006334c1fbfa58585db34ecc6f17938f2e305496 #v2.19.0
 
       - name: Update kubewarden-defaults Helm chart
         if: endsWith(github.event.client_payload.repository, 'policy-server')


### PR DESCRIPTION
## Description

This reverts commit ec7f00eee78f3dabc53a5b46cdd6d827a2d54a8e. We can use a more recent version and still avoiding the issue. Therefore, downgrade updatecli to v2.19.0