### PR TITLE
Do not add default registry when policy module is a http URL.

### DIFF
--- a/charts/kubewarden-defaults/templates/_helpers.tpl
+++ b/charts/kubewarden-defaults/templates/_helpers.tpl
@@ -68,3 +68,11 @@ namespaceSelector:
 {{- "" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "policy-module" -}}
+{{- if or (not .registry) (hasPrefix "http" .module) -}}
+{{- printf "%s" .module -}}
+{{- else  -}}
+{{- printf "%s/%s" .registry .module -}}
+{{- end -}}
+{{- end }}

--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -10,7 +10,8 @@ metadata:
   name: {{ $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: '{{ template "system_default_registry" . }}{{ $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module }}'
+  {{ $scope := dict "module" $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module "registry" $.Values.common.cattle.systemDefaultRegistry  }}
+  module: {{ template "policy-module" $scope }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
     - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/capabilities-policy.yaml
+++ b/charts/kubewarden-defaults/templates/capabilities-policy.yaml
@@ -10,7 +10,8 @@ metadata:
   name: {{ $.Values.recommendedPolicies.capabilitiesPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: '{{ template "system_default_registry" . }}{{ $.Values.recommendedPolicies.capabilitiesPolicy.module }}'
+  {{ $scope := dict "module" $.Values.recommendedPolicies.capabilitiesPolicy.module "registry" $.Values.common.cattle.systemDefaultRegistry  }}
+  module: {{ template "policy-module" $scope }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
   - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
@@ -10,7 +10,8 @@ metadata:
   name: {{ $.Values.recommendedPolicies.hostNamespacePolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: '{{ template "system_default_registry" . }}{{ $.Values.recommendedPolicies.hostNamespacePolicy.module }}'
+  {{ $scope := dict "module" $.Values.recommendedPolicies.hostNamespacePolicy.module "registry" $.Values.common.cattle.systemDefaultRegistry  }}
+  module: {{ template "policy-module" $scope }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
   - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/host-path-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-path-policy.yaml
@@ -10,7 +10,8 @@ metadata:
   name: {{ $.Values.recommendedPolicies.hostPathsPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: '{{ template "system_default_registry" . }}{{ $.Values.recommendedPolicies.hostPathsPolicy.module }}'
+  {{ $scope := dict "module" $.Values.recommendedPolicies.hostPathsPolicy.module "registry" $.Values.common.cattle.systemDefaultRegistry  }}
+  module: {{ template "policy-module" $scope }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
   - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
+++ b/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
@@ -10,7 +10,8 @@ metadata:
   name: {{ $.Values.recommendedPolicies.podPrivilegedPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: '{{ template "system_default_registry" . }}{{ $.Values.recommendedPolicies.podPrivilegedPolicy.module }}'
+  {{ $scope := dict "module" $.Values.recommendedPolicies.podPrivilegedPolicy.module "registry" $.Values.common.cattle.systemDefaultRegistry  }}
+  module: {{ template "policy-module" $scope }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
     - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/user-group-policy.yaml
+++ b/charts/kubewarden-defaults/templates/user-group-policy.yaml
@@ -10,7 +10,8 @@ metadata:
   name: {{ $.Values.recommendedPolicies.userGroupPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: '{{ template "system_default_registry" . }}{{ $.Values.recommendedPolicies.userGroupPolicy.module }}'
+  {{ $scope := dict "module" $.Values.recommendedPolicies.userGroupPolicy.module "registry" $.Values.common.cattle.systemDefaultRegistry  }}
+  module: {{ template "policy-module" $scope }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
     - apiGroups: [""]


### PR DESCRIPTION
## Description

Updates the recommended policies templates to add the default registry only when the policy module is not a http URL. Thus, the module URL to use is the module defined in the values file. Otherwise, the policy module URL is  built based on the `defaultSystemRegistry` and the policy module as it before

Fix #202

## Test

```shell
# change your values file...
make generate-values &&  helm template --set recommendedPolicies.enabled=True charts/kubewarden-defaults/ | grep "module"
  module: https://susemanager.suse/pub/kubewarden/ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.1.11
  module: ghcr.io/kubewarden/policies/capabilities-psp:v0.1.10
  module: ghcr.io/kubewarden/policies/host-namespaces-psp:v0.1.3
  module: ghcr.io/kubewarden/policies/hostpaths-psp:v0.1.6
  module: ghcr.io/kubewarden/policies/pod-privileged:v0.2.4
  module: ghcr.io/kubewarden/policies/user-group-psp:v0.4.2
```