### PR TITLE
Kubewarden components changelog in the chart release.

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -73,6 +73,12 @@ jobs:
         run: |
           make generate-policies-file
 
+      - name: Generate changelog files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          make generate-changelog-files
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 imagelist.txt
 policylist.txt
+CHANGELOG.md

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ generate-images-file:
 generate-policies-file:
 	@./scripts/extract_policies.sh ./charts
 
+.PHONY: generate-changelog-files
+generate-changelog-files:
+	@./scripts/generate_changelog_files.sh ./charts imagelist.txt
+
 .PHONY: shellcheck
 shellcheck:
 	shellcheck scripts/*

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,2 @@
+release-notes-file: CHANGELOG.md
+generate-release-notes: true

--- a/scripts/generate_changelog_files.sh
+++ b/scripts/generate_changelog_files.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+CHART_DIR=$1
+IMAGELIST_FILENAME=$2
+TMP_CHANGELOG_FILE_PATH=/tmp/changelog.md
+
+CONTROLLER_VERSION=$(grep "kubewarden-controller" < "$IMAGELIST_FILENAME" | sed "s/.*kubewarden-controller:\(\)/\1/g")
+CONTROLLER_URL=$(gh release view "$CONTROLLER_VERSION" --repo kubewarden/kubewarden-controller --json "url" | jq -r ".url" )
+POLICY_SERVER_VERSION=$(grep "policy-server" < "$IMAGELIST_FILENAME" | sed "s/.*policy-server:\(\)/\1/g")
+POLICY_SERVER_URL=$(gh release view "$POLICY_SERVER_VERSION" --repo kubewarden/policy-server --json "url" | jq -r ".url" )
+
+echo "Kubewarden controller [changelog]($CONTROLLER_URL)" >> $TMP_CHANGELOG_FILE_PATH
+echo "Policy server [changelog]($POLICY_SERVER_URL)" >> $TMP_CHANGELOG_FILE_PATH
+cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-controller/CHANGELOG.md"
+cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-defaults/CHANGELOG.md"
+cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-crds/CHANGELOG.md"
+


### PR DESCRIPTION
## Description

Configure Helm chart releaser to add links to the Kubewarden components (controller and policy server) in the Helm charts releases.

Fix #204 
