### PR TITLE
Bump kubewarden-defaults version to v1.5.5.

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -19,7 +19,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.4
+version: 1.5.5
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
@@ -31,7 +31,7 @@ annotations:
   # optional ones:
   catalog.cattle.io/hidden: true # Hide specific charts. Only use on CRD charts.
   catalog.cattle.io/auto-install: kubewarden-crds=1.2.3 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
-  catalog.cattle.io/upstream-version: "1.5.4" # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.5.5" # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool


### PR DESCRIPTION
## Description

Bumps kubewarden-defaults version to release the fix the issue in the recommended policies modules when the user uses http module URLs.

