### PR TITLE
Add missing appVersion field.

### DIFF
--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -21,6 +21,8 @@ keywords:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.2.3
+# This is the version of Kubewarden stack
+appVersion: "1.5.0"
 
 annotations:
   # required ones:

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -20,6 +20,8 @@ keywords:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.5.5
+# This is the version of Kubewarden stack
+appVersion: "1.5.0"
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart


### PR DESCRIPTION
## Description

The kubearden-crds and kubewarden-defaults charts are missing the appVersion field to store the Kubewarden stack version. This commit adds the field in the Helm charts.


