### PR TITLE
appVersion should show release candidate version.

### DIFF
--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -21,6 +21,8 @@ keywords:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.2.3
+# This is the version of Kubewarden stack
+appVersion: "1.5.0"
 
 annotations:
   # required ones:

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -20,6 +20,8 @@ keywords:
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.5.5
+# This is the version of Kubewarden stack
+appVersion: "1.5.0"
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart

--- a/updatecli/updatecli.d/major-kubewarden-update-with-crd-update.yaml
+++ b/updatecli/updatecli.d/major-kubewarden-update-with-crd-update.yaml
@@ -10,6 +10,13 @@ sources:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
       key: "version"
 
+  defaultChartAppVersion:
+    name: Load chart app version
+    kind: yaml
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "appVersion"
+
   defaultChartValuesFile:
     kind: yaml
     spec:
@@ -25,8 +32,6 @@ sources:
   controllerChartAppVersion:
     name: Load chart app version
     kind: yaml
-    transformers:
-      - semverinc: '{{ requiredEnv .semverinc }}'
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "appVersion"
@@ -51,6 +56,7 @@ sources:
     spec:
       file: "charts/kubewarden-controller/values.yaml"
       key: "image.tag"
+
   crdChartVersion:
     kind: yaml
     transformers:
@@ -58,6 +64,13 @@ sources:
     spec:
       file: "charts/kubewarden-crds/Chart.yaml"
       key: "version"
+
+  crdChartAppVersion:
+    name: Load chart app version
+    kind: yaml
+    spec:
+      file: "file://charts/kubewarden-crds/Chart.yaml"
+      key: "appVersion"
 
 
 conditions:
@@ -129,6 +142,16 @@ targets:
       key: 'version'
       value: '{{ source "crdChartVersion" }}'
 
+  updateCRDChartAppVersion:
+    name: Bump crds chart app version
+    kind: yaml
+    sourceid: crdChartAppVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-crds/Chart.yaml"
+      key: "appVersion"
+      value: '{{ requiredEnv .releaseVersion }}'
+
   defaultUpdateChartValuesFile:
     name: "Update container image in the chart-values.yaml file"
     kind: yaml
@@ -157,6 +180,16 @@ targets:
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
       key: "version"
+
+  defaultChartAppVersionUpdate:
+    name: Bump defaults chart app version
+    kind: yaml
+    sourceid: defaultChartAppVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "appVersion"
+      value: '{{ requiredEnv .releaseVersion }}'
 
   defaultChartVersionUpdate2:
     name: Bump defaults chart version in annotations
@@ -206,6 +239,7 @@ targets:
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "appVersion"
+      value: '{{ requiredEnv .releaseVersion }}'
 
   controllerChartVersionUpdate:
     name: Bump controller chart version

--- a/updatecli/updatecli.d/major-kubewarden-update.yaml
+++ b/updatecli/updatecli.d/major-kubewarden-update.yaml
@@ -10,6 +10,13 @@ sources:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
       key: "version"
 
+  defaultChartAppVersion:
+    name: Load chart app version
+    kind: yaml
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "appVersion"
+
   defaultChartValuesFile:
     kind: yaml
     spec:
@@ -25,8 +32,6 @@ sources:
   controllerChartAppVersion:
     name: Load chart app version
     kind: yaml
-    transformers:
-      - semverinc: '{{ requiredEnv .semverinc }}'
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "appVersion"
@@ -122,6 +127,16 @@ targets:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
       key: 'annotations.catalog\.cattle\.io/upstream-version'
 
+  defaultChartAppVersionUpdate:
+    name: Bump defaults chart app version
+    kind: yaml
+    sourceid: defaultChartAppVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "appVersion"
+      value: '{{ requiredEnv .releaseVersion }}'
+
 
   controllerUpdateChartValuesFile:
     name: "Update container image in the chart-values.yaml file"
@@ -151,6 +166,7 @@ targets:
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "appVersion"
+      value: '{{ requiredEnv .releaseVersion }}'
 
   controllerChartVersionUpdate:
     name: Bump controller chart version


### PR DESCRIPTION
## Description
    
Changes the updatecli script to set the value of appVersion field in the Helm charts the release from the Kubewarden components. Therefore, the release candidate suffix will not be lost. This is necessary because updatecli does not have semver transformer to release candidates.
