### PR TITLE
Run update CI on prerelease version bump.

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -45,8 +45,12 @@ jobs:
           if [[ $VALID == "invalid" ]]; then
                   exit 1
           fi
-
           UPDATE_TYPE=$(semver diff $OLDVERSION $NEWVERSION)
+          if [[ $UPDATE_TYPE == "prerelease" ]];then
+                UPDATE_TYPE="minor"
+          fi
+
+
           echo "update_type=$UPDATE_TYPE" >> $GITHUB_OUTPUT
           echo "repository=$REPOSITORY" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

The CI script used to updated the Helm charts was not running when the version is a release candidate. This change ensures that the major and minor script will be run when the version change is a release candidate bump

