### PR TITLE
Fix script to detect CRDs update in major/minor updates.

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -214,9 +214,9 @@ jobs:
           # Here the commands are used to detect CRDs changes. In the script they are used
           # to install the CRDs
           tar -xvf /tmp/crds.tar.gz
-          find . -maxdepth 1 -name "*policyserver*" -exec  mv \{\} charts/kubewarden-crds/templates/policyservers.yaml \;
-          find . -maxdepth 1 -name "*admissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/admissionpolicies.yaml \;
-          find . -maxdepth 1 -name "*clusteradmissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
+          find . -maxdepth 1 -name "*_policyserver*" -exec  mv \{\} charts/kubewarden-crds/templates/policyservers.yaml \;
+          find . -maxdepth 1 -name "*_admissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/admissionpolicies.yaml \;
+          find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
 
 
           set +e


### PR DESCRIPTION
## Description

The script used to detect CRDs update can replace the cluster admission policies CRD definition by the admission policy one. Due the file name filter used in the find command. This fixes the issue adding a "_" in front of the name pattern.

