### PR TITLE
Fix yq concatenation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,14 +27,14 @@ jobs:
         id: get-controller
         shell: bash
         run: |
-          echo "controller-image-repository=$(helm show values charts/kubewarden-controller | yq  '.common.cattle.systemDefaultRegistry+"/"+.image.repository')" >> $GITHUB_OUTPUT
+          echo "controller-image-repository=$(helm show values charts/kubewarden-controller | yq  '.common.cattle.systemDefaultRegistry + "/" + .image.repository')" >> $GITHUB_OUTPUT
           echo "controller-image-tag=$(helm show values charts/kubewarden-controller | yq  '.image.tag')" >> $GITHUB_OUTPUT
 
       - name: "Get policy server container image"
         id: get-policy-server
         shell: bash
         run: |
-          echo "policy-server-repository=$(helm show values charts/kubewarden-defaults | yq  '.common.cattle.systemDefaultRegistry+"/"+.policyServer.image.repository')" >> $GITHUB_OUTPUT
+          echo "policy-server-repository=$(helm show values charts/kubewarden-defaults | yq  '.common.cattle.systemDefaultRegistry + "/" + .policyServer.image.repository')" >> $GITHUB_OUTPUT
           echo "policy-server-tag=$(helm show values charts/kubewarden-defaults | yq '.policyServer.image.tag')" >> $GITHUB_OUTPUT
 
   run-e2e-tests:


### PR DESCRIPTION
Error in our runs: https://github.com/kubewarden/helm-charts/actions/runs/4699099020/jobs/8332177916#step:4:16
Fix for: https://github.com/kubewarden/kubewarden-end-to-end-tests/issues/57

```bash
~ echo "controller-image-repository=$(helm show values charts/kubewarden-controller | yqgo  '.common.cattle.systemDefaultRegistry+"/"+.image.repository')"
controller-image-repository=null

~ echo "controller-image-repository=$(helm show values charts/kubewarden-controller | yqgo  '.common.cattle.systemDefaultRegistry + "/" + .image.repository')"
controller-image-repository=ghcr.io/kubewarden/kubewarden-controller
```