### PR TITLE
Prerelease update script

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -47,10 +47,6 @@ jobs:
                   exit 1
           fi
           UPDATE_TYPE=$(semver diff $OLDVERSION $NEWVERSION)
-          if [[ $UPDATE_TYPE == "prerelease" ]];then
-                UPDATE_TYPE="minor"
-          fi
-
           PRERELEASE_SUFFIX="-$(semver get prerelease $NEWVERSION)"
           if [[ $PRERELEASE_SUFFIX == "-" ]];then
                 PRERELEASE_SUFFIX=" "
@@ -138,12 +134,12 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: "updatecli apply --config ./updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml --values updatecli/values.yaml"
 
-  major-minor-update:
+  major-minor-prerelease-update:
     name: Major or minor release updates
     runs-on: ubuntu-latest
     needs:
       - check-update-type
-    if: needs.check-update-type.outputs.update_type == 'major' || needs.check-update-type.outputs.update_type == 'minor'
+    if: needs.check-update-type.outputs.update_type == 'major' || needs.check-update-type.outputs.update_type == 'minor' || needs.check-update-type.outputs.update_type == 'prerelease'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -226,8 +222,8 @@ jobs:
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@v2
 
-      - name: Update Kubewarden charts with NO CRDs update
-        if: steps.update_crds.outputs.must_update_crds_chart==0
+      - name: Major or minor update Kubewarden charts with NO CRDs update
+        if: steps.update_crds.outputs.must_update_crds_chart==0 &&  (needs.check-update-type.outputs.update_type == 'major' || needs.check-update-type.outputs.update_type == 'minor')
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UPDATECLI_SEMVERINC_UPDATE: ${{ needs.check-update-type.outputs.update_type }}
@@ -236,8 +232,8 @@ jobs:
           UPDATECLI_CHART_VERSION: ${{ github.event.client_payload.version }}
         run: "updatecli apply --config ./updatecli/updatecli.d/major-kubewarden-update.yaml --values updatecli/values.yaml"
 
-      - name: Update Kubewarden charts WITH CRDs update
-        if: steps.update_crds.outputs.must_update_crds_chart==1
+      - name: Major or minor update Kubewarden charts WITH CRDs update
+        if: steps.update_crds.outputs.must_update_crds_chart==1 &&  (needs.check-update-type.outputs.update_type == 'major' || needs.check-update-type.outputs.update_type == 'minor')
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UPDATECLI_SEMVERINC_UPDATE: ${{ needs.check-update-type.outputs.update_type }}
@@ -245,3 +241,23 @@ jobs:
           UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
           UPDATECLI_CHART_VERSION: ${{ github.event.client_payload.version }}
         run: "updatecli apply --config ./updatecli/updatecli.d/major-kubewarden-update-with-crd-update.yaml --values updatecli/values.yaml"
+
+      - name: Prerelease update Kubewarden charts with NO CRDs update
+        if: steps.update_crds.outputs.must_update_crds_chart==0 && needs.check-update-type.outputs.update_type == 'prerelease'
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_SEMVERINC_UPDATE: ${{ needs.check-update-type.outputs.update_type }}
+          UPDATECLI_PRERELEASE_SUFFIX: ${{ needs.check-update-type.outputs.prerelease }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+          UPDATECLI_CHART_VERSION: ${{ github.event.client_payload.version }}
+        run: "updatecli apply --config ./updatecli/updatecli.d/prerelease-kubewarden-update.yaml --values updatecli/values.yaml"
+
+      - name: Prerelease update Kubewarden charts WITH CRDs update
+        if: steps.update_crds.outputs.must_update_crds_chart==1 && needs.check-update-type.outputs.update_type == 'prerelease'
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_SEMVERINC_UPDATE: ${{ needs.check-update-type.outputs.update_type }}
+          UPDATECLI_PRERELEASE_SUFFIX: ${{ needs.check-update-type.outputs.prerelease }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+          UPDATECLI_CHART_VERSION: ${{ github.event.client_payload.version }}
+        run: "updatecli apply --config ./updatecli/updatecli.d/prerelease-kubewarden-update-with-crd-update.yaml --values updatecli/values.yaml"

--- a/updatecli/updatecli.d/prerelease-kubewarden-update-with-crd-update.yaml
+++ b/updatecli/updatecli.d/prerelease-kubewarden-update-with-crd-update.yaml
@@ -1,0 +1,319 @@
+name: Prerelease update Kubewarden chart versions
+
+sources:
+  defaultChartVersion:
+    name: Load chart version
+    kind: yaml
+    transformers:
+      - findsubmatch:
+          pattern: '^\d+.\d+.\d+'
+      - addsuffix: '{{ requiredEnv .prerelease_suffix }}'
+      - trimsuffix: ' '
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "version"
+
+  defaultChartAppVersion:
+    name: Load chart app version
+    kind: yaml
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "appVersion"
+
+  defaultChartValuesFile:
+    kind: yaml
+    spec:
+      file: "charts/kubewarden-defaults/chart-values.yaml"
+      key: 'policyServer.image.tag'
+
+  defaultValuesFile:
+    kind: yaml
+    spec:
+      file: "charts/kubewarden-defaults/values.yaml"
+      key: 'policyServer.image.tag'
+
+  controllerChartAppVersion:
+    name: Load chart app version
+    kind: yaml
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: "appVersion"
+
+  controllerChartVersion:
+    name: Load controller chart version
+    kind: yaml
+    transformers:
+      - findsubmatch:
+          pattern: '^\d+.\d+.\d+'
+      - addsuffix: '{{ requiredEnv .prerelease_suffix }}'
+      - trimsuffix: ' '
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: "version"
+
+  controllerChartValuesFile:
+    kind: yaml
+    spec:
+      file: "charts/kubewarden-controller/chart-values.yaml"
+      key: "image.tag"
+
+  controllerValuesFile:
+    kind: yaml
+    spec:
+      file: "charts/kubewarden-controller/values.yaml"
+      key: "image.tag"
+
+  crdChartVersion:
+    kind: yaml
+    transformers:
+      - findsubmatch:
+          pattern: '^\d+.\d+.\d+'
+      - addsuffix: '{{ requiredEnv .prerelease_suffix }}'
+      - trimsuffix: ' '
+    spec:
+      file: "charts/kubewarden-crds/Chart.yaml"
+      key: "version"
+
+  crdChartAppVersion:
+    name: Load chart app version
+    kind: yaml
+    spec:
+      file: "file://charts/kubewarden-crds/Chart.yaml"
+      key: "appVersion"
+
+
+conditions:
+  # All the major 3 components must have the same tag
+  kwctlTag:
+    name: Test if kwctl has the required tag
+    disablesourceinput: true
+    kind: gittag
+    scmid: kwctlGit
+    spec:
+      versionfilter:
+        kind: "semver"
+        pattern: '{{ requiredEnv .releaseVersion }}'
+  kubewardenControllerTag:
+    name: Test if kubewarden-controller has the required tag
+    disablesourceinput: true
+    kind: gittag
+    scmid: kubewardenControllerGit
+    spec:
+      versionfilter:
+        kind: "semver"
+        pattern: '{{ requiredEnv .releaseVersion }}'
+  policyServerTag:
+    name: Test if Policy Server has the required tag
+    disablesourceinput: true
+    kind: gittag
+    scmid: policyServerGit
+    spec:
+      versionfilter:
+        kind: "semver"
+        pattern: '{{ requiredEnv .releaseVersion }}'
+
+targets:
+  installCRD:
+    name: "Updates CRDs"
+    kind: shell
+    scmid: "default"
+    disablesourceinput: true
+    spec:
+      command: bash updatecli/scripts/install_crds.sh
+
+  updateControllerAutoInstallAnnotation:
+    name: "Update kubewarden-controller auto-install annotation"
+    kind: yaml
+    sourceid: crdChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: 'annotations.catalog\.cattle\.io/auto-install'
+      value: 'kubewarden-crds={{ source "crdChartVersion" }}'
+
+  updateCRDUpstreamVersionAnnotation:
+    name: "Update kubewarden-crds upstream-version annotation"
+    kind: yaml
+    sourceid: crdChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-crds/Chart.yaml"
+      key: 'annotations.catalog\.cattle\.io/upstream-version'
+      value: '{{ source "crdChartVersion" }}'
+
+  updateCRDChartVersion:
+    name: "Update kubewarden-crds version"
+    kind: yaml
+    sourceid: crdChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-crds/Chart.yaml"
+      key: 'version'
+      value: '{{ source "crdChartVersion" }}'
+
+  updateCRDChartAppVersion:
+    name: Bump crds chart app version
+    kind: yaml
+    sourceid: crdChartAppVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-crds/Chart.yaml"
+      key: "appVersion"
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  defaultUpdateChartValuesFile:
+    name: "Update container image in the chart-values.yaml file"
+    kind: yaml
+    sourceid: defaultChartValuesFile
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-defaults/chart-values.yaml"
+      key: 'policyServer.image.tag'
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  defaultUpdateValuesFile:
+    kind: yaml
+    name: "Update container image in the values.yaml file"
+    sourceid: defaultValuesFile
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-defaults/values.yaml"
+      key: 'policyServer.image.tag'
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  defaultChartVersionUpdate:
+    name: Bump defaults chart version
+    kind: yaml
+    sourceid: defaultChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "version"
+
+  defaultChartAppVersionUpdate:
+    name: Bump defaults chart app version
+    kind: yaml
+    sourceid: defaultChartAppVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "appVersion"
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  defaultChartVersionUpdate2:
+    name: Bump defaults chart version in annotations
+    kind: yaml
+    sourceid: defaultChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: 'annotations.catalog\.cattle\.io/upstream-version'
+
+  updateDefautlsAutoInstallAnnotation:
+    name: "Update kubewarden-defautls auto-install annotation"
+    kind: yaml
+    sourceid: crdChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: 'annotations.catalog\.cattle\.io/auto-install'
+      value: 'kubewarden-crds={{ source "crdChartVersion" }}'
+
+
+  controllerUpdateChartValuesFile:
+    name: "Update container image in the chart-values.yaml file"
+    kind: yaml
+    sourceid: defaultChartValuesFile
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-controller/chart-values.yaml"
+      key: 'image.tag'
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  controllerUpdateValuesFile:
+    kind: yaml
+    name: "Update container image in the values.yaml file"
+    sourceid: controllerValuesFile
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-controller/values.yaml"
+      key: 'image.tag'
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  controllerChartAppVersionUpdate:
+    name: Bump controller chart app version
+    kind: yaml
+    sourceid: controllerChartAppVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: "appVersion"
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  controllerChartVersionUpdate:
+    name: Bump controller chart version
+    kind: yaml
+    sourceid: controllerChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: "version"
+
+  controllerChartVersionUpdate2:
+    name: Bump controller chart version in annotations
+    kind: yaml
+    sourceid: controllerChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: 'annotations.catalog\.cattle\.io/upstream-version'
+
+actions:
+  createUpdatePR:
+    title: "Helm chart {{ requiredEnv .semverinc }} release"
+    helm-charts:
+    kind: "github/pullrequest"
+    scmid: "default"
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic Helm chart {{ requiredEnv .semverinc }} update.
+        This PR has been created by the automation used to automatically update the Helm charts when some Kubewarden component is released
+
+        REMEMBER IF YOU WANT TO MERGE IN A SINGLE COMMIT CHANGES AND VERSION BUMP, YOU MUST SQUASH THE COMMIT BEFORE MERGING THIS PR!
+      draft: false
+      labels:
+        - "kind/enhancement"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      directory: "/tmp/helm-charts"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "helm-charts"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ .github.branch }}"
+      commitmessage:
+        type: "fix"
+        title: "Update Kubewarden Helm charts"
+        hidecredit: true
+  kwctlGit:
+    kind: "git"
+    spec:
+        url: "https://github.com/{{ requiredEnv .github.user }}/kwctl.git"
+        branch: "main"
+  kubewardenControllerGit:
+    kind: "git"
+    spec:
+        url: "https://github.com/{{ requiredEnv .github.user }}/kubewarden-controller.git"
+        branch: "main"
+  policyServerGit:
+    kind: "git"
+    spec:
+        url: "https://github.com/{{ requiredEnv .github.user }}/policy-server.git"
+        branch: "main"

--- a/updatecli/updatecli.d/prerelease-kubewarden-update.yaml
+++ b/updatecli/updatecli.d/prerelease-kubewarden-update.yaml
@@ -1,0 +1,243 @@
+name: Update Kubewarden chart versions
+
+sources:
+  defaultChartVersion:
+    name: Load chart version
+    kind: yaml
+    transformers:
+      - findsubmatch:
+          pattern: '^\d+.\d+.\d+'
+      - addsuffix: '{{ requiredEnv .prerelease_suffix }}'
+      - trimsuffix: ' '
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "version"
+
+  defaultChartAppVersion:
+    name: Load chart app version
+    kind: yaml
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "appVersion"
+
+  defaultChartValuesFile:
+    kind: yaml
+    spec:
+      file: "charts/kubewarden-defaults/chart-values.yaml"
+      key: 'policyServer.image.tag'
+
+  defaultValuesFile:
+    kind: yaml
+    spec:
+      file: "charts/kubewarden-defaults/values.yaml"
+      key: 'policyServer.image.tag'
+
+  controllerChartAppVersion:
+    name: Load chart app version
+    kind: yaml
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: "appVersion"
+
+  controllerChartVersion:
+    name: Load controller chart version
+    kind: yaml
+    transformers:
+      - findsubmatch:
+          pattern: '^\d+.\d+.\d+'
+      - addsuffix: '{{ requiredEnv .prerelease_suffix }}'
+      - trimsuffix: ' '
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: "version"
+
+  controllerChartValuesFile:
+    kind: yaml
+    spec:
+      file: "charts/kubewarden-controller/chart-values.yaml"
+      key: "image.tag"
+
+  controllerValuesFile:
+    kind: yaml
+    spec:
+      file: "charts/kubewarden-controller/values.yaml"
+      key: "image.tag"
+
+
+conditions:
+  # All the major 3 components must have the same tag
+  kwctlTag:
+    name: Test if kwctl has the required tag
+    disablesourceinput: true
+    kind: gittag
+    scmid: kwctlGit
+    spec:
+      versionfilter:
+        kind: "semver"
+        pattern: '{{ requiredEnv .releaseVersion }}'
+  kubewardenControllerTag:
+    name: Test if kubewarden-controller has the required tag
+    disablesourceinput: true
+    kind: gittag
+    scmid: kubewardenControllerGit
+    spec:
+      versionfilter:
+        kind: "semver"
+        pattern: '{{ requiredEnv .releaseVersion }}'
+  policyServerTag:
+    name: Test if Policy Server has the required tag
+    disablesourceinput: true
+    kind: gittag
+    scmid: policyServerGit
+    spec:
+      versionfilter:
+        kind: "semver"
+        pattern: '{{ requiredEnv .releaseVersion }}'
+
+targets:
+  defaultUpdateChartValuesFile:
+    name: "Update container image in the chart-values.yaml file"
+    kind: yaml
+    sourceid: defaultChartValuesFile
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-defaults/chart-values.yaml"
+      key: 'policyServer.image.tag'
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  defaultUpdateValuesFile:
+    kind: yaml
+    name: "Update container image in the values.yaml file"
+    sourceid: defaultValuesFile
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-defaults/values.yaml"
+      key: 'policyServer.image.tag'
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  defaultChartVersionUpdate:
+    name: Bump defaults chart version
+    kind: yaml
+    sourceid: defaultChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "version"
+
+  defaultChartVersionUpdate2:
+    name: Bump defaults chart version in annotations
+    kind: yaml
+    sourceid: defaultChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: 'annotations.catalog\.cattle\.io/upstream-version'
+
+  defaultChartAppVersionUpdate:
+    name: Bump defaults chart app version
+    kind: yaml
+    sourceid: defaultChartAppVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-defaults/Chart.yaml"
+      key: "appVersion"
+      value: '{{ requiredEnv .releaseVersion }}'
+
+
+  controllerUpdateChartValuesFile:
+    name: "Update container image in the chart-values.yaml file"
+    kind: yaml
+    sourceid: defaultChartValuesFile
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-controller/chart-values.yaml"
+      key: 'image.tag'
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  controllerUpdateValuesFile:
+    kind: yaml
+    name: "Update container image in the values.yaml file"
+    sourceid: controllerValuesFile
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-controller/values.yaml"
+      key: 'image.tag'
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  controllerChartAppVersionUpdate:
+    name: Bump controller chart app version
+    kind: yaml
+    sourceid: controllerChartAppVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: "appVersion"
+      value: '{{ requiredEnv .releaseVersion }}'
+
+  controllerChartVersionUpdate:
+    name: Bump controller chart version
+    kind: yaml
+    sourceid: controllerChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: "version"
+
+  controllerChartVersionUpdate2:
+    name: Bump controller chart version in annotations
+    kind: yaml
+    sourceid: controllerChartVersion
+    scmid: "default"
+    spec:
+      file: "file://charts/kubewarden-controller/Chart.yaml"
+      key: 'annotations.catalog\.cattle\.io/upstream-version'
+
+actions:
+  createUpdatePR:
+    title: "Helm chart {{ requiredEnv .semverinc }} release"
+    helm-charts:
+    kind: "github/pullrequest"
+    scmid: "default"
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic Helm chart {{ requiredEnv .semverinc }} update.
+        This PR has been created by the automation used to automatically update the Helm charts when some Kubewarden component is released
+
+        REMEMBER IF YOU WANT TO MERGE IN A SINGLE COMMIT CHANGES AND VERSION BUMP, YOU MUST SQUASH THE COMMIT BEFORE MERGING THIS PR!
+      draft: false
+      labels:
+        - "kind/enhancement"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      directory: "/tmp/helm-charts"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "helm-charts"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ .github.branch }}"
+      commitmessage:
+        type: "fix"
+        title: "Update Kubewarden Helm charts"
+        hidecredit: true
+  kwctlGit:
+    kind: "git"
+    spec:
+        url: "https://github.com/{{ requiredEnv .github.user }}/kwctl.git"
+        branch: "main"
+  kubewardenControllerGit:
+    kind: "git"
+    spec:
+        url: "https://github.com/{{ requiredEnv .github.user }}/kubewarden-controller.git"
+        branch: "main"
+  policyServerGit:
+    kind: "git"
+    spec:
+        url: "https://github.com/{{ requiredEnv .github.user }}/policy-server.git"
+        branch: "main"


### PR DESCRIPTION
## Description

Adds the updatecli scripts to update the Helm chart when a new release candidate is released.

## Test

```shell
curl \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR API TOKEN>"\
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/jvanz/helm-charts/dispatches \
  -d '{"event_type":"update-chart","client_payload":{"version": "v1.7.0-rc1", "oldVersion": "v1.6.0", "repository": "jvanz/kwctl"}}'
```
[PR](https://github.com/jvanz/helm-charts/pull/64/files) created after the above command

```shell
curl \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR API TOKEN>"\
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/jvanz/helm-charts/dispatches \
  -d '{"event_type":"update-chart","client_payload":{"version": "v1.7.0-rc2", "oldVersion": "v1.7.0-rc1", "repository": "jvanz/kwctl"}}'
```
[PR](https://github.com/jvanz/helm-charts/pull/65/files) created after the above command


```shell
curl \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR API TOKEN>"\
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/jvanz/helm-charts/dispatches \
  -d '{"event_type":"update-chart","client_payload":{"version": "v1.7.0", "oldVersion": "v1.7.0-rc2", "repository": "jvanz/kwctl"}}'
```
[PR](https://github.com/jvanz/helm-charts/pull/66/files) created after the above command