### PR TITLE
fix!: Remove `.Values.telemetry` from kubewarden-defaults

### DIFF
--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -28,8 +28,6 @@ policyServer:
     - apiGroup: "networking.k8s.io"
       resources:
         - ingresses
-  telemetry:
-    enabled: False
   env:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -18,20 +18,11 @@ spec:
   verificationConfig: {{ .Values.policyServer.verificationConfig }}
   {{- end }}
   annotations:
-    {{- if .Values.policyServer.telemetry.enabled }}
-      "sidecar.opentelemetry.io/inject": "true"
-    {{- end }}
     {{- range $key, $value := .Values.policyServer.annotations }}
       {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
-  {{- if or .Values.policyServer.env .Values.policyServer.telemetry.enabled }}
+  {{- if .Values.policyServer.env }}
   env:
-    {{- if .Values.policyServer.telemetry.enabled }}
-    - name: KUBEWARDEN_ENABLE_METRICS
-      value: "1"
-    - name: KUBEWARDEN_LOG_FMT
-      value: otlp
-    {{- end }}
     {{- range .Values.policyServer.env }}
     - name: {{ .name | quote }}
       value: {{ .value | quote }}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -40,8 +40,6 @@ policyServer:
     - apiGroup: "networking.k8s.io"
       resources:
         - ingresses
-  telemetry:
-    enabled: False
   env:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/ui/issues/287

Now the controller is the one in charge of configuring PolicyServers with telemetry enabled.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Tested in the controller side.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
