### PR TITLE
kubewarden-defaults: v1.6.1 chart version bump.

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -19,7 +19,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.6.1
 # This is the version of Kubewarden stack
 appVersion: "v1.6.0"
 annotations:
@@ -33,7 +33,7 @@ annotations:
   # optional ones:
   catalog.cattle.io/hidden: true # Hide specific charts. Only use on CRD charts.
   catalog.cattle.io/auto-install: kubewarden-crds=1.3.0 # Similar to requires but auto-installed, not manually installed. Accepts `match`, or a specific version.
-  catalog.cattle.io/upstream-version: "1.6.0" # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
+  catalog.cattle.io/upstream-version: "1.6.1" # The version of the upstream chart or app. It prevents the unexpected "downgrade" when upgrading an installed chart that uses our 100.x.x+upVersion version schema.
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool


### PR DESCRIPTION
## Description

Updates the kubewarden-defaults chart version to v1.6.1. This version has the change removing unnecessary telemetry configuration after a change in the controller where this configuration are added by automatically.
