### PR TITLE
feat: Add audit-scanner as experimental feature

### DIFF
--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -103,6 +103,12 @@ resources:
 experimental:
   auditScanner:
     enable: true
+    # The default audit-scanner ServiceAccount is bound to the ClusterRoles:
+    # - view: Allows read-only access to most objects in a namespace.
+    #   Does not allow viewing secrets, roles or role bindings.
+    # - audit-scanner-cluster-role: Allows read-write to Kubewarden resources
+    #   and PolicyReports
+    serviceAccountName: audit-scanner
     image:
       # The registry is defined in the common.cattle.systemDefaultRegistry value
       # kubectl image to be used in the pre-delete helm hook

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -54,6 +54,7 @@ image:
   repository: "kubewarden/kubewarden-controller"
   # image tag
   tag: "v1.6.2"
+  pullPolicy: IfNotPresent
 
 preDeleteJob:
   image:

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -20,19 +20,22 @@ additionalAnnotations: {}
 # of the container
 containerSecurityContext:
   allowPrivilegeEscalation: false
+
 # SecurityContext to be used in the controller pod. The content of
 # the podSecurityContext will be set directly as the securityContext
 # of the pod
 podSecurityContext:
   runAsNonRoot: true
+
+# SecurityContext to be used in the pre-delete-hook job container and pod.
+# The content of the next fields will be set directly as the securityContext
+# of the container and pod used in the pre-delete-hook job.
 preDeleteHook:
-  # SecurityContext to be used in the pre-delete-hook job container and pod.
-  # The content of the next fields will be set directly as the securityContext
-  # of the container and pod used in the pre-delete-hook job.
   containerSecurityContext:
     allowPrivilegeEscalation: false
   podSecurityContext:
     runAsNonRoot: true
+
 # open-telemetry options
 telemetry:
   enabled: False
@@ -44,18 +47,21 @@ telemetry:
     # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:14250"
     # tls:
     #  insecure: true
+
 image:
   # The registry is defined in the common.cattle.systemDefaultRegistry value
   # controller image to be used
   repository: "kubewarden/kubewarden-controller"
   # image tag
   tag: "v1.6.2"
+
 preDeleteJob:
   image:
     # The registry is defined in the common.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/kubectl"
     tag: "v1.25.9"
+
 # kubewarden-controller deployment settings:
 podAnnotations: {}
 nodeSelector: {}
@@ -72,8 +78,9 @@ tls:
   source: cert-manager-self-signed
   # "cert-manager"-only options:
   certManagerIssuerName: ""
-## Resource limits & requests
-## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+
+# Resource limits & requests
+# Ref: https://kubernetes.io/docs/user-guide/compute-resources/
 resources:
   controller:
     limits:

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -90,3 +90,27 @@ resources:
     requests:
       cpu: 250m
       memory: 50Mi
+  auditScanner:
+    limits:
+      cpu: 500m
+      memory: 50Mi
+    requests:
+      cpu: 250m
+      memory: 50Mi
+
+# experimental Kubewarden features. These features are not recommended for
+# production yet, and are not covered by SemVer guarantees.
+experimental:
+  auditScanner:
+    enable: true
+    image:
+      # The registry is defined in the common.cattle.systemDefaultRegistry value
+      # kubectl image to be used in the pre-delete helm hook
+      repository: "kubewarden/audit-scanner"
+      tag: "latest"
+      pullPolicy: IfNotPresent
+    cronJob:
+      schedule: "*/60 * * * *" # every 60 minutes
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 3
+    containerRestartPolicy: Never

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -15,14 +15,14 @@ additionalLabels: {}
 additionalAnnotations: {}
 #   owner: IT-group1
 
-# SecurityContext to be used in the controller container. The content of
-# the containerSecurityContext will be set directly as the securityContext
-# of the container
+# SecurityContext to be used in the controller and audit-scanner containers. The
+# content of the containerSecurityContext will be set directly as the
+# securityContext of the container
 containerSecurityContext:
   allowPrivilegeEscalation: false
 
-# SecurityContext to be used in the controller pod. The content of
-# the podSecurityContext will be set directly as the securityContext
+# SecurityContext to be used in the controller and audit-scanner pods. The
+# content of the podSecurityContext will be set directly as the securityContext
 # of the pod
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -24,6 +24,24 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create default fully qualified audit-scanner name
+Truncate to 53 per CronJob docs, as k8s controller appends chars when spawning
+the job Pods.
+*/}}
+{{- define "audit-scanner.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{-   .Values.fullnameOverride | trunc 53 | trimSuffix "-" }}
+{{- else }}
+{{-   $name := default "audit-scanner" .Values.nameOverride }}
+{{-   if contains $name .Release.Name }}
+{{-     .Release.Name | trunc 53 | trimSuffix "-" }}
+{{-   else }}
+{{-     $name | trunc 53 | trimSuffix "-" }}
+{{-   end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "kubewarden-controller.chart" -}}
@@ -65,10 +83,17 @@ Annotations
 {{- end }}
 
 {{/*
-Create the name of the service account to use
+Create the name of the service account to use for kubewarden-controller
 */}}
 {{- define "kubewarden-controller.serviceAccountName" -}}
 {{- include "kubewarden-controller.fullname" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for audit-scanner
+*/}}
+{{- define "audit-scanner.serviceAccountName" -}}
+{{- include "audit-scanner.fullname" . }}
 {{- end }}
 
 {{- define "system_default_registry" -}}

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -89,13 +89,6 @@ Create the name of the service account to use for kubewarden-controller
 {{- include "kubewarden-controller.fullname" . }}
 {{- end }}
 
-{{/*
-Create the name of the service account to use for audit-scanner
-*/}}
-{{- define "audit-scanner.serviceAccountName" -}}
-{{- include "audit-scanner.fullname" . }}
-{{- end }}
-
 {{- define "system_default_registry" -}}
 {{- if .Values.common.cattle.systemDefaultRegistry -}}
 {{- printf "%s/" .Values.common.cattle.systemDefaultRegistry -}}

--- a/charts/kubewarden-controller/templates/cronjob.yaml
+++ b/charts/kubewarden-controller/templates/cronjob.yaml
@@ -32,7 +32,7 @@ spec:
             image: '{{ template "system_default_registry" . }}{{ .Values.experimental.auditScanner.image.repository }}:{{ .Values.experimental.auditScanner.image.tag }}'
             imagePullPolicy: {{ .Values.experimental.auditScanner.image.pullPolicy }}
             command:
-              # TODO update to scan all namespaces
+              # TODO update to scan all namespaces and cluster-wide resources
               - /audit-scanner
               - --namespace
               - default

--- a/charts/kubewarden-controller/templates/cronjob.yaml
+++ b/charts/kubewarden-controller/templates/cronjob.yaml
@@ -22,7 +22,7 @@ spec:
           securityContext:
           {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.imagePullSecrets }}
+          {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
           {{- toYaml .Values.imagePullSecrets | nindent 12 }}
           {{- end }}

--- a/charts/kubewarden-controller/templates/cronjob.yaml
+++ b/charts/kubewarden-controller/templates/cronjob.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.experimental.auditScanner.enable }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "audit-scanner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.experimental.auditScanner.cronJob.schedule | quote }}
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: {{ .Values.experimental.auditScanner.cronJob.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.experimental.auditScanner.cronJob.successfulJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ include "audit-scanner.serviceAccountName" . }}
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.imagePullSecrets }}
+          imagePullSecrets:
+          {{- toYaml .Values.imagePullSecrets | nindent 12 }}
+          {{- end }}
+          restartPolicy: {{ .Values.experimental.auditScanner.containerRestartPolicy }}
+          containers:
+          - name: audit-scanner
+            image: '{{ template "system_default_registry" . }}{{ .Values.experimental.auditScanner.image.repository }}:{{ .Values.experimental.auditScanner.image.tag }}'
+            imagePullPolicy: {{ .Values.experimental.auditScanner.image.pullPolicy }}
+            command:
+              # TODO update to scan all namespaces
+              - /audit-scanner
+              - --namespace
+              - default
+              - --loglevel
+              - info
+            {{- with .Values.containerSecurityContext }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.nodeSelector }}
+            nodeSelector:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.affinity }}
+            affinity:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.tolerations }}
+            tolerations:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- if and .Values.resources .Values.resources.auditScanner }}
+            resources:
+{{ toYaml .Values.resources.auditScanner | indent 14 }}
+            {{- end }}
+{{ end }}

--- a/charts/kubewarden-controller/templates/cronjob.yaml
+++ b/charts/kubewarden-controller/templates/cronjob.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       template:
         spec:
-          serviceAccountName: {{ include "audit-scanner.serviceAccountName" . }}
+          serviceAccountName: {{ .Values.experimental.auditScanner.serviceAccountName }}
           {{- with .Values.podSecurityContext }}
           securityContext:
           {{- toYaml . | nindent 12 }}

--- a/charts/kubewarden-controller/templates/rbac.yaml
+++ b/charts/kubewarden-controller/templates/rbac.yaml
@@ -220,35 +220,14 @@ rules:
   resources:
   - clusteradmissionpolicies
   - admissionpolicies
+  - clusteradmissionpolicies/status
+  - admissionpolicies/status
+  - policyservers
+  - policyservers/status
   verbs:
   - get
   - list
   - watch
-- apiGroups:
-  - policies.kubewarden.io
-  resources:
-  - clusteradmissionpolicies/status
-  - admissionpolicies/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-    - policies.kubewarden.io
-  resources:
-    - policyservers
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
-    - policies.kubewarden.io
-  resources:
-    - policyservers/status
-  verbs:
-    - get
-    - list
-    - watch
 - apiGroups:
     - wgpolicyk8s.io
   resources:
@@ -261,14 +240,6 @@ rules:
     - list
     - patch
     - update
-    - watch
-- apiGroups:
-    - '*'
-  resources:
-    - '*'
-  verbs:
-    - get
-    - list
     - watch
 {{- end }}
 ---

--- a/charts/kubewarden-controller/templates/rbac.yaml
+++ b/charts/kubewarden-controller/templates/rbac.yaml
@@ -206,6 +206,71 @@ rules:
   - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: audit-scanner-cluster-role
+  labels:
+    {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
+rules:
+- apiGroups:
+  - policies.kubewarden.io
+  resources:
+  - clusteradmissionpolicies
+  - admissionpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policies.kubewarden.io
+  resources:
+  - clusteradmissionpolicies/status
+  - admissionpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+    - policies.kubewarden.io
+  resources:
+    - policyservers
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - policies.kubewarden.io
+  resources:
+    - policyservers/status
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - wgpolicyk8s.io
+  resources:
+    - policyreports
+    - clusterpolicyreports
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - '*'
+  resources:
+    - '*'
+  verbs:
+    - get
+    - list
+    - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kubewarden-controller-leader-election-rolebinding
@@ -273,4 +338,21 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kubewarden-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: audit-scanner-cluster-role
+  labels:
+    {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: audit-scanner-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "audit-scanner.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/kubewarden-controller/templates/rbac.yaml
+++ b/charts/kubewarden-controller/templates/rbac.yaml
@@ -204,6 +204,7 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+{{- if eq .Values.experimental.auditScanner.serviceAccountName  "audit-scanner" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -269,6 +270,7 @@ rules:
     - get
     - list
     - watch
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -339,6 +341,24 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kubewarden-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- if eq .Values.experimental.auditScanner.serviceAccountName "audit-scanner" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: audit-scanner-cluster-role-viewer
+  labels:
+    {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.experimental.auditScanner.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -354,5 +374,6 @@ roleRef:
   name: audit-scanner-cluster-role
 subjects:
 - kind: ServiceAccount
-  name: {{ include "audit-scanner.serviceAccountName" . }}
+  name: {{ .Values.experimental.auditScanner.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/kubewarden-controller/templates/serviceaccount.yaml
+++ b/charts/kubewarden-controller/templates/serviceaccount.yaml
@@ -7,3 +7,13 @@ metadata:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
   annotations:
     {{- include "kubewarden-controller.annotations" . | nindent 4 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "audit-scanner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubewarden-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}

--- a/charts/kubewarden-controller/templates/serviceaccount.yaml
+++ b/charts/kubewarden-controller/templates/serviceaccount.yaml
@@ -7,13 +7,16 @@ metadata:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
   annotations:
     {{- include "kubewarden-controller.annotations" . | nindent 4 }}
+
+{{- if eq .Values.experimental.auditScanner.serviceAccountName "audit-scanner" }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "audit-scanner.serviceAccountName" . }}
+  name: {{ .Values.experimental.auditScanner.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubewarden-controller.labels" . | nindent 4 }}
   annotations:
     {{- include "kubewarden-controller.annotations" . | nindent 4 }}
+{{ end }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -102,3 +102,27 @@ resources:
     requests:
       cpu: 250m
       memory: 50Mi
+  auditScanner:
+    limits:
+      cpu: 500m
+      memory: 50Mi
+    requests:
+      cpu: 250m
+      memory: 50Mi
+
+# experimental Kubewarden features. These features are not recommended for
+# production yet, and are not covered by SemVer guarantees.
+experimental:
+  auditScanner:
+    enable: true
+    image:
+      # The registry is defined in the common.cattle.systemDefaultRegistry value
+      # kubectl image to be used in the pre-delete helm hook
+      repository: "kubewarden/audit-scanner"
+      tag: "latest"
+      pullPolicy: IfNotPresent
+    cronJob:
+      schedule: "*/60 * * * *" # every 60 minutes
+      failedJobsHistoryLimit: 5
+      successfulJobsHistoryLimit: 3
+    containerRestartPolicy: Never

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -115,6 +115,12 @@ resources:
 experimental:
   auditScanner:
     enable: true
+    # The default audit-scanner ServiceAccount is bound to the ClusterRoles:
+    # - view: Allows read-only access to most objects in a namespace.
+    #   Does not allow viewing secrets, roles or role bindings.
+    # - audit-scanner-cluster-role: Allows read-write to Kubewarden resources
+    #   and PolicyReports
+    serviceAccountName: audit-scanner
     image:
       # The registry is defined in the common.cattle.systemDefaultRegistry value
       # kubectl image to be used in the pre-delete helm hook

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -27,14 +27,14 @@ additionalLabels: {}
 additionalAnnotations: {}
 #   owner: IT-group1
 
-# SecurityContext to be used in the controller container. The content of
-# the containerSecurityContext will be set directly as the securityContext
-# of the container
+# SecurityContext to be used in the controller and audit-scanner containers. The
+# content of the containerSecurityContext will be set directly as the
+# securityContext of the container
 containerSecurityContext:
   allowPrivilegeEscalation: false
 
-# SecurityContext to be used in the controller pod. The content of
-# the podSecurityContext will be set directly as the securityContext
+# SecurityContext to be used in the controller and audit-scanner pods. The
+# content of the podSecurityContext will be set directly as the securityContext
 # of the pod
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -32,19 +32,22 @@ additionalAnnotations: {}
 # of the container
 containerSecurityContext:
   allowPrivilegeEscalation: false
+
 # SecurityContext to be used in the controller pod. The content of
 # the podSecurityContext will be set directly as the securityContext
 # of the pod
 podSecurityContext:
   runAsNonRoot: true
+
+# SecurityContext to be used in the pre-delete-hook job container and pod.
+# The content of the next fields will be set directly as the securityContext
+# of the container and pod used in the pre-delete-hook job.
 preDeleteHook:
-  # SecurityContext to be used in the pre-delete-hook job container and pod.
-  # The content of the next fields will be set directly as the securityContext
-  # of the container and pod used in the pre-delete-hook job.
   containerSecurityContext:
     allowPrivilegeEscalation: false
   podSecurityContext:
     runAsNonRoot: true
+
 # open-telemetry options
 telemetry:
   enabled: False
@@ -56,18 +59,21 @@ telemetry:
     # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:14250"
     # tls:
     #  insecure: true
+
 image:
   # The registry is defined in the common.cattle.systemDefaultRegistry value
   # controller image to be used
   repository: "kubewarden/kubewarden-controller"
   # image tag
   tag: "v1.6.2"
+
 preDeleteJob:
   image:
     # The registry is defined in the common.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/kubectl"
     tag: "v1.25.9"
+
 # kubewarden-controller deployment settings:
 podAnnotations: {}
 nodeSelector: {}
@@ -84,8 +90,9 @@ tls:
   source: cert-manager-self-signed
   # "cert-manager"-only options:
   certManagerIssuerName: ""
-## Resource limits & requests
-## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+
+# Resource limits & requests
+# Ref: https://kubernetes.io/docs/user-guide/compute-resources/
 resources:
   controller:
     limits:

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -66,6 +66,7 @@ image:
   repository: "kubewarden/kubewarden-controller"
   # image tag
   tag: "v1.6.2"
+  pullPolicy: IfNotPresent
 
 preDeleteJob:
   image:

--- a/charts/kubewarden-crds/templates/admissionpolicies.yaml
+++ b/charts/kubewarden-crds/templates/admissionpolicies.yaml
@@ -23,6 +23,10 @@ spec:
       jsonPath: .spec.mutating
       name: Mutating
       type: boolean
+    - description: Whether the policy is used in audit checks
+      jsonPath: .spec.backgroundAudit
+      name: BackgroundAudit
+      type: boolean
     - description: Policy deployment mode
       jsonPath: .spec.mode
       name: Mode
@@ -55,6 +59,13 @@ spec:
           spec:
             description: AdmissionPolicySpec defines the desired state of AdmissionPolicy
             properties:
+              backgroundAudit:
+                default: true
+                description: BackgroundAudit indicates whether a policy should be
+                  used or skipped when performing audit checks. If false, the policy
+                  cannot produce meaningful evaluation results during audit checks
+                  and will be skipped. The default is "true".
+                type: boolean
               failurePolicy:
                 description: FailurePolicy defines how unrecognized errors and timeout
                   errors from the policy are handled. Allowed values are "Ignore"

--- a/charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml
+++ b/charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml
@@ -23,6 +23,10 @@ spec:
       jsonPath: .spec.mutating
       name: Mutating
       type: boolean
+    - description: Whether the policy is used in audit checks
+      jsonPath: .spec.backgroundAudit
+      name: BackgroundAudit
+      type: boolean
     - description: Policy deployment mode
       jsonPath: .spec.mode
       name: Mode
@@ -56,6 +60,13 @@ spec:
           spec:
             description: ClusterAdmissionPolicySpec defines the desired state of ClusterAdmissionPolicy
             properties:
+              backgroundAudit:
+                default: true
+                description: BackgroundAudit indicates whether a policy should be
+                  used or skipped when performing audit checks. If false, the policy
+                  cannot produce meaningful evaluation results during audit checks
+                  and will be skipped. The default is "true".
+                type: boolean
               contextAwareResources:
                 description: List of Kubernetes resources the policy is allowed to
                   access at evaluation time. Access to these resources is done using


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Partially implements https://github.com/kubewarden/helm-charts/issues/237
Missing: shipping CRDs and depending on them.

- Add ServiceAccount and ClusterRole
- Add cronjob.yaml templat
- Add new experiemental values.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Follow https://github.com/kubewarden/audit-scanner/blob/main/CONTRIBUTING.md.

Once you have Kubewarden and all CRDs installed, checkout the `feat-audit` branch on kubewarden/helm-charts,
and do:

```
helm upgrade -i --wait --namespace kubewarden \
  --create-namespace kubewarden-controller ./kubewarden-controller \
  --set image.tag=latest-feat-audit --set image.repository=viccuad/kubewarden-controller
```

## Additional Information

Note: PR against `feat-audit` branch.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

Missing shipping and depending on CRDs.
Missing skipping namespaces.
