### PR TITLE
fix!: rename common.cattle.* to global.cattle.*

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,14 +27,14 @@ jobs:
         id: get-controller
         shell: bash
         run: |
-          echo "controller-image-repository=$(helm show values charts/kubewarden-controller | yq  '.common.cattle.systemDefaultRegistry + "/" + .image.repository')" >> $GITHUB_OUTPUT
+          echo "controller-image-repository=$(helm show values charts/kubewarden-controller | yq  '.global.cattle.systemDefaultRegistry + "/" + .image.repository')" >> $GITHUB_OUTPUT
           echo "controller-image-tag=$(helm show values charts/kubewarden-controller | yq  '.image.tag')" >> $GITHUB_OUTPUT
 
       - name: "Get policy server container image"
         id: get-policy-server
         shell: bash
         run: |
-          echo "policy-server-repository=$(helm show values charts/kubewarden-defaults | yq  '.common.cattle.systemDefaultRegistry + "/" + .policyServer.image.repository')" >> $GITHUB_OUTPUT
+          echo "policy-server-repository=$(helm show values charts/kubewarden-defaults | yq  '.global.cattle.systemDefaultRegistry + "/" + .policyServer.image.repository')" >> $GITHUB_OUTPUT
           echo "policy-server-tag=$(helm show values charts/kubewarden-defaults | yq '.policyServer.image.tag')" >> $GITHUB_OUTPUT
 
   run-e2e-tests:

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -45,14 +45,14 @@ telemetry:
     # tls:
     #  insecure: true
 image:
-  # The registry is defined in the common.cattle.systemDefaultRegistry value
+  # The registry is defined in the global.cattle.systemDefaultRegistry value
   # controller image to be used
   repository: "kubewarden/kubewarden-controller"
   # image tag
   tag: "v1.6.2"
 preDeleteJob:
   image:
-    # The registry is defined in the common.cattle.systemDefaultRegistry value
+    # The registry is defined in the global.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/kubectl"
     tag: "v1.25.9"

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -72,8 +72,8 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "system_default_registry" -}}
-{{- if .Values.common.cattle.systemDefaultRegistry -}}
-{{- printf "%s/" .Values.common.cattle.systemDefaultRegistry -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
 {{- else -}}
 {{- "" -}}
 {{- end -}}

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -35,8 +35,8 @@ spec:
         args:
         - --leader-elect
         - --deployments-namespace={{ .Release.Namespace }}
-        {{- if .Values.common.policyServer.default.enabled }}
-        - --default-policy-server={{ .Values.common.policyServer.default.name }}
+        {{- if .Values.global.policyServer.default.enabled }}
+        - --default-policy-server={{ .Values.global.policyServer.default.name }}
         {{- end }}
        {{- if .Values.telemetry.enabled }}
         - --enable-metrics

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -3,7 +3,7 @@
 # Common settings across multiple charts. These settings will be used
 # by more than one chart and they ideally need to match during the
 # installation of the charts consuming this values.
-common:
+global:
   cattle:
     systemDefaultRegistry: ghcr.io
   policyServer:
@@ -57,14 +57,14 @@ telemetry:
     # tls:
     #  insecure: true
 image:
-  # The registry is defined in the common.cattle.systemDefaultRegistry value
+  # The registry is defined in the global.cattle.systemDefaultRegistry value
   # controller image to be used
   repository: "kubewarden/kubewarden-controller"
   # image tag
   tag: "v1.6.2"
 preDeleteJob:
   image:
-    # The registry is defined in the common.cattle.systemDefaultRegistry value
+    # The registry is defined in the global.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/kubectl"
     tag: "v1.25.9"

--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -10,7 +10,7 @@ additionalAnnotations: {}
 policyServer:
   replicaCount: 1
   image:
-    # The registry is defined in the common.cattle.systemDefaultRegistry value
+    # The registry is defined in the global.cattle.systemDefaultRegistry value
     repository: "kubewarden/policy-server"
     tag: "v1.6.0"
   serviceAccountName: policy-server

--- a/charts/kubewarden-defaults/templates/_helpers.tpl
+++ b/charts/kubewarden-defaults/templates/_helpers.tpl
@@ -62,22 +62,18 @@ namespaceSelector:
 {{- end -}}
 
 {{- define "system_default_registry" -}}
-{{- if .Values.common.cattle.systemDefaultRegistry -}}
-{{- printf "%s/" .Values.common.cattle.systemDefaultRegistry -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
 {{- else -}}
 {{- "" -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "policy-module" -}}
-{{- if (hasPrefix "http" .module) -}}
-{{- printf "%s" .module -}}
-{{- else  -}}
-{{- if .registry -}}
-{{- printf "%s/%s" .registry .module -}}
-{{- else  -}}
-{{- printf "%s/%s" .systemDefaultRegistry .module -}}
-{{- end -}}
+{{- define "policy_default_registry" -}}
+{{- if .Values.recommendedPolicies.defaultPoliciesRegistry -}}
+{{- printf "%s/" .Values.recommendedPolicies.defaultPoliciesRegistry -}}
+{{- else -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -10,8 +10,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  {{ $scope := dict "module" $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module "registry" $.Values.recommendedPolicies.defaultPoliciesRegistry "systemDefaultRegistry" $.Values.common.cattle.systemDefaultRegistry}}
-  module: {{ template "policy-module" $scope }}
+  module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
     - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/capabilities-policy.yaml
+++ b/charts/kubewarden-defaults/templates/capabilities-policy.yaml
@@ -10,8 +10,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.capabilitiesPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  {{ $scope := dict "module" $.Values.recommendedPolicies.capabilitiesPolicy.module "registry" $.Values.recommendedPolicies.defaultPoliciesRegistry "systemDefaultRegistry" $.Values.common.cattle.systemDefaultRegistry}}
-  module: {{ template "policy-module" $scope }}
+  module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.capabilitiesPolicy.module }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
   - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
@@ -10,8 +10,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.hostNamespacePolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  {{ $scope := dict "module" $.Values.recommendedPolicies.hostNamespacePolicy.module "registry" $.Values.recommendedPolicies.defaultPoliciesRegistry "systemDefaultRegistry" $.Values.common.cattle.systemDefaultRegistry}}
-  module: {{ template "policy-module" $scope }}
+  module: {{ template "policy_default_registry" . }}{{.Values.recommendedPolicies.hostNamespacePolicy.module}}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
   - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/host-path-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-path-policy.yaml
@@ -10,8 +10,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.hostPathsPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  {{ $scope := dict "module" $.Values.recommendedPolicies.hostPathsPolicy.module "registry" $.Values.recommendedPolicies.defaultPoliciesRegistry "systemDefaultRegistry" $.Values.common.cattle.systemDefaultRegistry}}
-  module: {{ template "policy-module" $scope }}
+  module: {{ template "policy_default_registry" . }}{{.Values.recommendedPolicies.hostPathsPolicy.module}}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
   - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
+++ b/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
@@ -10,8 +10,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.podPrivilegedPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  {{ $scope := dict "module" $.Values.recommendedPolicies.podPrivilegedPolicy.module "registry" $.Values.recommendedPolicies.defaultPoliciesRegistry "systemDefaultRegistry" $.Values.common.cattle.systemDefaultRegistry}}
-  module: {{ template "policy-module" $scope }}
+  module: {{ template "policy_default_registry" . }}{{.Values.recommendedPolicies.podPrivilegedPolicy.module}}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
     - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.common.policyServer.default.enabled }}
+{{- if .Values.global.policyServer.default.enabled }}
 apiVersion: {{ $.Values.crdVersion }}
 kind: PolicyServer
 metadata:
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: policy-server
   annotations:
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
-  name: {{ .Values.common.policyServer.default.name }}
+  name: {{ .Values.global.policyServer.default.name }}
   finalizers:
     - kubewarden
 spec:

--- a/charts/kubewarden-defaults/templates/user-group-policy.yaml
+++ b/charts/kubewarden-defaults/templates/user-group-policy.yaml
@@ -10,8 +10,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.userGroupPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  {{ $scope := dict "module" $.Values.recommendedPolicies.userGroupPolicy.module "registry" $.Values.recommendedPolicies.defaultPoliciesRegistry "systemDefaultRegistry" $.Values.common.cattle.systemDefaultRegistry}}
-  module: {{ template "policy-module" $scope }}
+  module: {{ template "policy_default_registry" . }}{{.Values.recommendedPolicies.userGroupPolicy.module}}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
     - apiGroups: [""]

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -3,7 +3,7 @@
 # Common settings across multiple charts. These settings will be used
 # by more than one chart and they ideally need to match during the
 # installation of the charts consuming this values.
-common:
+global:
   cattle:
     systemDefaultRegistry: ghcr.io
   policyServer:
@@ -22,7 +22,7 @@ additionalAnnotations: {}
 policyServer:
   replicaCount: 1
   image:
-    # The registry is defined in the common.cattle.systemDefaultRegistry value
+    # The registry is defined in the global.cattle.systemDefaultRegistry value
     repository: "kubewarden/policy-server"
     tag: "v1.6.0"
   serviceAccountName: policy-server

--- a/common-values.yaml
+++ b/common-values.yaml
@@ -1,7 +1,7 @@
 # Common settings across multiple charts. These settings will be used
 # by more than one chart and they ideally need to match during the
 # installation of the charts consuming this values.
-common:
+global:
   cattle:
     systemDefaultRegistry: ghcr.io
   policyServer:


### PR DESCRIPTION
## Description

Updates the global configuration values used by all the charts from common.cattle.* to global.cattle.* to follow the Rancher standards.

Fix #241 

