### PR TITLE
Revert acidental  kubewarden-crds chart release

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,21 @@ See the `values.yaml` file of the chart for the configuration values.
 required by the Kubewarden stack. It should be installed before installing
 `kubewarden-controller` and `kubewarden-defaults` charts.
 
+## Contents
+
+This chart installs Kubewarden CRDs:
+  `admissionpolicies.policies.kubewarden.io`
+  `clusteradmissionpolicies.policies.kubewarden.io`
+  `policyservers.policies.kubewarden.io`
+
+It also installs PolicyReports CRDs:
+  `policyreports.wgpolicyk8s.io`
+  `clusterpolicyreports.wgpolicyk8s.io`
+
+To skip installing these (maybe because for example they are already installed
+and owned by a different Helm Release), set the value `policyReports.enable` to
+`false`.
+
 ## Installing
 
 For example:

--- a/README.md
+++ b/README.md
@@ -254,21 +254,6 @@ See the `values.yaml` file of the chart for the configuration values.
 required by the Kubewarden stack. It should be installed before installing
 `kubewarden-controller` and `kubewarden-defaults` charts.
 
-## Contents
-
-This chart installs Kubewarden CRDs:
-  `admissionpolicies.policies.kubewarden.io`
-  `clusteradmissionpolicies.policies.kubewarden.io`
-  `policyservers.policies.kubewarden.io`
-
-It also installs PolicyReports CRDs:
-  `policyreports.wgpolicyk8s.io`
-  `clusterpolicyreports.wgpolicyk8s.io`
-
-To skip installing these (maybe because for example they are already installed
-and owned by a different Helm Release), set the value `policyReports.enable` to
-`false`.
-
 ## Installing
 
 For example:

--- a/index.yaml
+++ b/index.yaml
@@ -1608,39 +1608,6 @@ entries:
       catalog.cattle.io/os: linux
       catalog.cattle.io/release-name: rancher-kubewarden-crds
       catalog.cattle.io/type: cluster-tool
-      catalog.cattle.io/upstream-version: 1.4.0
-    apiVersion: v2
-    appVersion: v1.6.0
-    created: "2023-06-27T08:04:07.545581507Z"
-    description: A Helm chart for deploying the Kubewarden CRDs
-    digest: 46320d4eb01809b4206cc72934f0d1e2981c0d9a246cc4bcb0e9832c566f9570
-    home: https://www.kubewarden.io/
-    icon: https://www.kubewarden.io/images/icon-kubewarden.svg
-    keywords:
-    - Security
-    - Infrastructure
-    - Monitoring
-    - policy agent
-    - validating webhook
-    - admissions controller
-    - policy report
-    kubeVersion: '>= 1.19.0-0'
-    maintainers:
-    - email: kubewarden@suse.de
-      name: Kubewarden Maintainers
-      url: https://github.com/orgs/kubewarden/teams/maintainers
-    name: kubewarden-crds
-    type: application
-    urls:
-    - https://github.com/kubewarden/helm-charts/releases/download/kubewarden-crds-1.4.0/kubewarden-crds-1.4.0.tgz
-    version: 1.4.0
-  - annotations:
-      catalog.cattle.io/certified: rancher
-      catalog.cattle.io/hidden: "true"
-      catalog.cattle.io/namespace: cattle-kubewarden-system
-      catalog.cattle.io/os: linux
-      catalog.cattle.io/release-name: rancher-kubewarden-crds
-      catalog.cattle.io/type: cluster-tool
       catalog.cattle.io/upstream-version: 1.3.1
     apiVersion: v2
     appVersion: v1.6.0
@@ -3243,4 +3210,4 @@ entries:
     urls:
     - https://github.com/kubewarden/helm-charts/releases/download/kubewarden-defaults-0.1.0/kubewarden-defaults-0.1.0.tgz
     version: 0.1.0
-generated: "2023-06-27T08:04:07.704569808Z"
+generated: "2023-05-18T13:49:33.688279116Z"


### PR DESCRIPTION
## Description

This PR revert the latest two commits which released by accident the `kubewarden-crds` helm chart. 
