### PR TITLE
Audit scanner skip system namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,6 @@ generate-values:
 .PHONY: check-generated-values
 check-generated-values: generate-values
 	@sh -c 'git diff --exit-code charts || (echo; echo "There are chart differences that have to be checked in"; exit 1)'
-	@diff <(cat charts/kubewarden-controller/values.yaml | yq .experimental.auditScanner.skipNamespaces) \
-		<(cat charts/kubewarden-defaults/values.yaml | yq .recommendedPolicies.skipNamespaces) \
-		|| (echo; echo "default skipNamespaces differ between charts")
 
 .PHONY: generate-images-file
 generate-images-file:

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -109,27 +109,4 @@ experimental:
       failedJobsHistoryLimit: 5
       successfulJobsHistoryLimit: 3
     containerRestartPolicy: Never
-    skipNamespaces:
-      - calico-system
-      - cattle-alerting
-      - cattle-fleet-local-system
-      - cattle-fleet-system
-      - cattle-global-data
-      - cattle-global-nt
-      - cattle-impersonation-system
-      - cattle-istio
-      - cattle-logging
-      - cattle-monitoring-system
-      - cattle-neuvector-system
-      - cattle-pipeline
-      - cattle-prometheus
-      - cattle-system
-      - cert-manager
-      - ingress-nginx
-      - kube-node-lease
-      - kube-public
-      - kube-system
-      - longhorn-system
-      - rancher-operator-system
-      - security-scan
-      - tigera-operator
+    skipAdditionalNamespaces: []

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -96,3 +96,15 @@ Create the name of the service account to use for kubewarden-controller
 {{- "" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "audit-scanner.command" -}}
+- /audit-scanner
+- --loglevel
+- info
+{{- range .Values.global.skipNamespaces }}
+- {{ printf "-i %s" . }}
+{{- end -}}
+{{- range .Values.experimental.auditScanner.skipAdditionalNamespaces }}
+- {{ printf "-i %s" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/kubewarden-controller/templates/cronjob.yaml
+++ b/charts/kubewarden-controller/templates/cronjob.yaml
@@ -32,12 +32,7 @@ spec:
             image: '{{ template "system_default_registry" . }}{{ .Values.experimental.auditScanner.image.repository }}:{{ .Values.experimental.auditScanner.image.tag }}'
             imagePullPolicy: {{ .Values.experimental.auditScanner.image.pullPolicy }}
             command:
-              # TODO update to scan all namespaces and cluster-wide resources
-              - /audit-scanner
-              - --namespace
-              - default
-              - --loglevel
-              - info
+              {{- include "audit-scanner.command" . | nindent 14 -}}
             {{- with .Values.containerSecurityContext }}
             securityContext:
               {{- toYaml . | nindent 14 }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -6,6 +6,30 @@
 global:
   cattle:
     systemDefaultRegistry: ghcr.io
+  skipNamespaces:
+    - calico-system
+    - cattle-alerting
+    - cattle-fleet-local-system
+    - cattle-fleet-system
+    - cattle-global-data
+    - cattle-global-nt
+    - cattle-impersonation-system
+    - cattle-istio
+    - cattle-logging
+    - cattle-monitoring-system
+    - cattle-neuvector-system
+    - cattle-pipeline
+    - cattle-prometheus
+    - cattle-system
+    - cert-manager
+    - ingress-nginx
+    - kube-node-lease
+    - kube-public
+    - kube-system
+    - longhorn-system
+    - rancher-operator-system
+    - security-scan
+    - tigera-operator
   policyServer:
     default:
       name: default
@@ -121,27 +145,4 @@ experimental:
       failedJobsHistoryLimit: 5
       successfulJobsHistoryLimit: 3
     containerRestartPolicy: Never
-    skipNamespaces:
-      - calico-system
-      - cattle-alerting
-      - cattle-fleet-local-system
-      - cattle-fleet-system
-      - cattle-global-data
-      - cattle-global-nt
-      - cattle-impersonation-system
-      - cattle-istio
-      - cattle-logging
-      - cattle-monitoring-system
-      - cattle-neuvector-system
-      - cattle-pipeline
-      - cattle-prometheus
-      - cattle-system
-      - cert-manager
-      - ingress-nginx
-      - kube-node-lease
-      - kube-public
-      - kube-system
-      - longhorn-system
-      - rancher-operator-system
-      - security-scan
-      - tigera-operator
+    skipAdditionalNamespaces: []

--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -67,30 +67,6 @@ recommendedPolicies:
   # not support OCI artifacts.
   # If this field is not defined, the systemDefaultRegistry is used by default.
   defaultPoliciesRegistry: ""
-  skipNamespaces:
-    - calico-system
-    - cattle-alerting
-    - cattle-fleet-local-system
-    - cattle-fleet-system
-    - cattle-global-data
-    - cattle-global-nt
-    - cattle-impersonation-system
-    - cattle-istio
-    - cattle-logging
-    - cattle-monitoring-system
-    - cattle-neuvector-system
-    - cattle-pipeline
-    - cattle-prometheus
-    - cattle-system
-    - cert-manager
-    - ingress-nginx
-    - kube-node-lease
-    - kube-public
-    - kube-system
-    - longhorn-system
-    - rancher-operator-system
-    - security-scan
-    - tigera-operator
   skipAdditionalNamespaces: []
   defaultPolicyMode: "monitor"
   allowPrivilegeEscalationPolicy:

--- a/charts/kubewarden-defaults/templates/_helpers.tpl
+++ b/charts/kubewarden-defaults/templates/_helpers.tpl
@@ -53,7 +53,7 @@ namespaceSelector:
   - key: "kubernetes.io/metadata.name"
     operator: NotIn
     values:
-{{- with .Values.recommendedPolicies.skipNamespaces }}
+{{- with .Values.global.skipNamespaces }}
       {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- with .Values.recommendedPolicies.skipAdditionalNamespaces }}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -6,6 +6,30 @@
 global:
   cattle:
     systemDefaultRegistry: ghcr.io
+  skipNamespaces:
+    - calico-system
+    - cattle-alerting
+    - cattle-fleet-local-system
+    - cattle-fleet-system
+    - cattle-global-data
+    - cattle-global-nt
+    - cattle-impersonation-system
+    - cattle-istio
+    - cattle-logging
+    - cattle-monitoring-system
+    - cattle-neuvector-system
+    - cattle-pipeline
+    - cattle-prometheus
+    - cattle-system
+    - cert-manager
+    - ingress-nginx
+    - kube-node-lease
+    - kube-public
+    - kube-system
+    - longhorn-system
+    - rancher-operator-system
+    - security-scan
+    - tigera-operator
   policyServer:
     default:
       name: default
@@ -79,30 +103,6 @@ recommendedPolicies:
   # not support OCI artifacts.
   # If this field is not defined, the systemDefaultRegistry is used by default.
   defaultPoliciesRegistry: ""
-  skipNamespaces:
-    - calico-system
-    - cattle-alerting
-    - cattle-fleet-local-system
-    - cattle-fleet-system
-    - cattle-global-data
-    - cattle-global-nt
-    - cattle-impersonation-system
-    - cattle-istio
-    - cattle-logging
-    - cattle-monitoring-system
-    - cattle-neuvector-system
-    - cattle-pipeline
-    - cattle-prometheus
-    - cattle-system
-    - cert-manager
-    - ingress-nginx
-    - kube-node-lease
-    - kube-public
-    - kube-system
-    - longhorn-system
-    - rancher-operator-system
-    - security-scan
-    - tigera-operator
   skipAdditionalNamespaces: []
   defaultPolicyMode: "monitor"
   allowPrivilegeEscalationPolicy:

--- a/common-values.yaml
+++ b/common-values.yaml
@@ -4,6 +4,30 @@
 global:
   cattle:
     systemDefaultRegistry: ghcr.io
+  skipNamespaces:
+    - calico-system
+    - cattle-alerting
+    - cattle-fleet-local-system
+    - cattle-fleet-system
+    - cattle-global-data
+    - cattle-global-nt
+    - cattle-impersonation-system
+    - cattle-istio
+    - cattle-logging
+    - cattle-monitoring-system
+    - cattle-neuvector-system
+    - cattle-pipeline
+    - cattle-prometheus
+    - cattle-system
+    - cert-manager
+    - ingress-nginx
+    - kube-node-lease
+    - kube-public
+    - kube-system
+    - longhorn-system
+    - rancher-operator-system
+    - security-scan
+    - tigera-operator
   policyServer:
     default:
       name: default


### PR DESCRIPTION
## Description

Both kubewarden-controller and kubewarden-defaults charts uses the skipNamespaces values. Therefore, the field now lives under the global values. The kubewarden-defaults helper template has also been update to fetch the values from the new location.

Change the audit scanner CronJob definition to build the command adding the flags to skip the system namespaces.

Fix #254

This PR is **blocked** by the merge of https://github.com/kubewarden/audit-scanner/pull/53