### PR TITLE
deps: Bump kubectl image to 1.26.6

### DIFF
--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -53,7 +53,7 @@ preDeleteJob:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/kubectl"
-    tag: "v1.25.9"
+    tag: "v1.26.6"
 # kubewarden-controller deployment settings:
 podAnnotations: {}
 nodeSelector: {}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -65,7 +65,7 @@ preDeleteJob:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/kubectl"
-    tag: "v1.25.9"
+    tag: "v1.26.6"
 # kubewarden-controller deployment settings:
 podAnnotations: {}
 nodeSelector: {}


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/kubewarden-controller/issues/465

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Bump to latest from https://github.com/kubewarden/rancher-kubectl-builder/pkgs/container/kubectl.
Default to audit-scanner disabled.

## Test

E2E tests.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
