### PR TITLE
feat: audit scanner enable by default.

### DIFF
--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -89,7 +89,7 @@ resources:
       memory: 50Mi
 
 auditScanner:
-  enable: false
+  enable: true
   # The default audit-scanner ServiceAccount is bound to the ClusterRoles:
   # - view: Allows read-only access to most objects in a namespace.
   #   Does not allow viewing secrets, roles or role bindings.

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -125,7 +125,7 @@ resources:
       memory: 50Mi
 
 auditScanner:
-  enable: false
+  enable: true
   # The default audit-scanner ServiceAccount is bound to the ClusterRoles:
   # - view: Allows read-only access to most objects in a namespace.
   #   Does not allow viewing secrets, roles or role bindings.


### PR DESCRIPTION
## Description

Updates the kubewarden-controller to enable the audit scanner component by default.

