### PR TITLE
feat: Consume policy-server-root-ca Secret in auditScanner Cronjob

### DIFF
--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -53,7 +53,7 @@ preDeleteJob:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/kubectl"
-    tag: "v1.26.6"
+    tag: "v1.27.4"
 # kubewarden-controller deployment settings:
 podAnnotations: {}
 nodeSelector: {}

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -101,6 +101,8 @@ Create the name of the service account to use for kubewarden-controller
 - /audit-scanner
 - --loglevel
 - info
+- --extra-ca
+- "/pki/policy-server-root-ca-pem"
 {{- range .Values.global.skipNamespaces }}
 - {{ printf "-i" }}
 - {{ printf "%s" . }}

--- a/charts/kubewarden-controller/templates/audit-scanner.yaml
+++ b/charts/kubewarden-controller/templates/audit-scanner.yaml
@@ -32,6 +32,9 @@ spec:
             secret:
               defaultMode: 420
               secretName: policy-server-root-ca
+              items:
+              - key: policy-server-root-ca-pem
+                path: "policy-server-root-ca-pem"
           containers:
           - name: audit-scanner
             image: '{{ template "system_default_registry" . }}{{ .Values.auditScanner.image.repository }}:{{ .Values.auditScanner.image.tag }}'
@@ -39,9 +42,6 @@ spec:
             command:
               {{- include "audit-scanner.command" . | nindent 14 -}}
             {{- with .Values.containerSecurityContext }}
-            env:
-            - name: KUBEWARDEN_CACERT_PEM_POLICYSERVERS
-              value: "/pki/policy-server-root-ca-pem"
             volumeMounts:
             - mountPath: "/pki"
               name: policyservers-ca-cert

--- a/charts/kubewarden-controller/templates/audit-scanner.yaml
+++ b/charts/kubewarden-controller/templates/audit-scanner.yaml
@@ -27,6 +27,11 @@ spec:
           {{- toYaml .Values.imagePullSecrets | nindent 12 }}
           {{- end }}
           restartPolicy: {{ .Values.auditScanner.containerRestartPolicy }}
+          volumes:
+          - name: policyservers-ca-cert
+            secret:
+              defaultMode: 420
+              secretName: policy-server-root-ca
           containers:
           - name: audit-scanner
             image: '{{ template "system_default_registry" . }}{{ .Values.auditScanner.image.repository }}:{{ .Values.auditScanner.image.tag }}'
@@ -34,6 +39,13 @@ spec:
             command:
               {{- include "audit-scanner.command" . | nindent 14 -}}
             {{- with .Values.containerSecurityContext }}
+            env:
+            - name: KUBEWARDEN_CACERT_PEM_POLICYSERVERS
+              value: "/pki/policy-server-root-ca-pem"
+            volumeMounts:
+            - mountPath: "/pki"
+              name: policyservers-ca-cert
+              readOnly: true
             securityContext:
               {{- toYaml . | nindent 14 }}
             {{- end }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -89,7 +89,7 @@ preDeleteJob:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/kubectl"
-    tag: "v1.26.6"
+    tag: "v1.27.4"
 # kubewarden-controller deployment settings:
 podAnnotations: {}
 nodeSelector: {}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Partial implementation of https://github.com/kubewarden/audit-scanner/issues/64
Needs an audit-scanner image with https://github.com/kubewarden/audit-scanner/pull/75


This is done with a volumeMount. The `policy-server-root-ca` is created by the kubewarden-controller deployment, but only when there is a policy-server. This means that the first installation of kubewarden-controller chart will deploy an audit-scanner cronjob that will continously fail, until there's a policy-server instantiated (normally when one installs the kubewarden-default chart).

This doesn't need to be this way, we can change the kubewarden-controller reconcile loop so it creates the ca secret without needing a policy-server first.


## Test

Tested locally, needs https://github.com/kubewarden/audit-scanner/pull/75

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
