### PR TITLE
build: Ignore prereleases on artifacthub 

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -3,3 +3,13 @@ repositoryID: 710272c4-d7d8-4c72-b104-ee010b22fb58
 owners:
 - name: Kubewarden developers
   email: kubewarden@suse.de
+ignore: # (optional, packages that should not be indexed by Artifact Hub)
+  - name: kubewarden-crds # Exact match
+    # match semver, and ignore prereleases (with `-`), but not builds ( with `+`)
+    version: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))+(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+  - name: kubewarden-controller # Exact match
+    # match semver, and ignore prereleases (with `-`), but not builds ( with `+`)
+    version: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))+(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+  - name: kubewarden-defaults # Exact match
+    # match semver, and ignore prereleases (with `-`), but not builds ( with `+`)
+    version: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))+(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$

--- a/scripts/extract_images.sh
+++ b/scripts/extract_images.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CHART_DIR=$1
-CHARTS_DIRS=$(find "$CHART_DIR" -type d -exec test -e '{}'/values.yaml \; -print)
+CHARTS_DIRS=$(find "$CHART_DIR" -type d -exec test -e '{}'/values.yaml \; -print | grep -v kubewarden-crds)
 IMAGELIST_FILENAME=imagelist.txt
 TMP_IMAGE_FILE=/tmp/$IMAGELIST_FILENAME
 

--- a/scripts/generate_changelog_files.sh
+++ b/scripts/generate_changelog_files.sh
@@ -9,9 +9,12 @@ CONTROLLER_VERSION=$(grep "kubewarden-controller" < "$IMAGELIST_FILENAME" | sed 
 CONTROLLER_URL=$(gh release view "$CONTROLLER_VERSION" --repo kubewarden/kubewarden-controller --json "url" | jq -r ".url" )
 POLICY_SERVER_VERSION=$(grep "policy-server" < "$IMAGELIST_FILENAME" | sed "s/.*policy-server:\(\)/\1/g")
 POLICY_SERVER_URL=$(gh release view "$POLICY_SERVER_VERSION" --repo kubewarden/policy-server --json "url" | jq -r ".url" )
+AUDIT_SCANNER_VERSION=$(grep "audit-scanner" < "$IMAGELIST_FILENAME" | sed "s/.*audit-scanner:\(\)/\1/g")
+AUDIT_SCANNER_URL=$(gh release view "$AUDIT_SCANNER_VERSION" --repo kubewarden/audit-scanner --json "url" | jq -r ".url" )
 
 echo "Kubewarden controller [changelog]($CONTROLLER_URL)" >> $TMP_CHANGELOG_FILE_PATH
 echo "Policy server [changelog]($POLICY_SERVER_URL)" >> $TMP_CHANGELOG_FILE_PATH
+echo "Audit scanner [changelog]($AUDIT_SCANNER_URL)" >> $TMP_CHANGELOG_FILE_PATH
 cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-controller/CHANGELOG.md"
 cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-defaults/CHANGELOG.md"
 cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-crds/CHANGELOG.md"

--- a/scripts/generate_changelog_files.sh
+++ b/scripts/generate_changelog_files.sh
@@ -11,10 +11,11 @@ POLICY_SERVER_VERSION=$(grep "policy-server" < "$IMAGELIST_FILENAME" | sed "s/.*
 POLICY_SERVER_URL=$(gh release view "$POLICY_SERVER_VERSION" --repo kubewarden/policy-server --json "url" | jq -r ".url" )
 AUDIT_SCANNER_VERSION=$(grep "audit-scanner" < "$IMAGELIST_FILENAME" | sed "s/.*audit-scanner:\(\)/\1/g")
 AUDIT_SCANNER_URL=$(gh release view "$AUDIT_SCANNER_VERSION" --repo kubewarden/audit-scanner --json "url" | jq -r ".url" )
-
-echo "Kubewarden controller [changelog]($CONTROLLER_URL)" >> $TMP_CHANGELOG_FILE_PATH
-echo "Policy server [changelog]($POLICY_SERVER_URL)" >> $TMP_CHANGELOG_FILE_PATH
-echo "Audit scanner [changelog]($AUDIT_SCANNER_URL)" >> $TMP_CHANGELOG_FILE_PATH
+{
+  echo "Kubewarden controller [changelog]($CONTROLLER_URL)"
+  echo "Policy server [changelog]($POLICY_SERVER_URL)"
+  echo "Audit scanner [changelog]($AUDIT_SCANNER_URL)"
+} >> $TMP_CHANGELOG_FILE_PATH
 cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-controller/CHANGELOG.md"
 cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-defaults/CHANGELOG.md"
 cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-crds/CHANGELOG.md"


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/helm-charts/issues/267

- build: Ignore prereleases on artifacthub
- fix: Don't generate imagelist.txt for kubewarden-crds
- feat: Consume changelogs from audit-scanner GH releases


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested from my fork.
See that https://artifacthub.io/packages/helm/viccuad-kw/kubewarden-controller doesn't contain -rc releases.


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
