### PR TITLE
feat: allow set controller replicas count.

### DIFF
--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -88,6 +88,9 @@ resources:
       cpu: 250m
       memory: 50Mi
 
+# Controller replicas
+replicas: 1
+
 auditScanner:
   enable: true
   # The default audit-scanner ServiceAccount is bound to the ClusterRoles:

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "kubewarden-controller.selectorLabels" . | nindent 6 }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -124,6 +124,9 @@ resources:
       cpu: 250m
       memory: 50Mi
 
+# Controller replicas
+replicas: 1
+
 auditScanner:
   enable: true
   # The default audit-scanner ServiceAccount is bound to the ClusterRoles:


### PR DESCRIPTION
## Description

Adds a new value to allow user to define the number of replicas used to run the Kubewarden controller.


Fix https://github.com/kubewarden/helm-charts/issues/266
