### PR TITLE
fix: allow user skip reports CRDs installation.

### DIFF
--- a/updatecli/scripts/install_crds.sh
+++ b/updatecli/scripts/install_crds.sh
@@ -8,6 +8,11 @@ find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec  mv \{\} /tmp/helm-
 tar -xvf /tmp/crds-audit-scanner.tar.gz
 find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
 find . -maxdepth 1 -name "*_policyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
+# add the if statement to allow users to skip the reports CRDs installation
+sed -i '1 i {{- if .Values.installPolicyReportCRDs }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
+sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
+sed -i '1 i {{- if .Values.installPolicyReportCRDs }}' charts/kubewarden-crds/templates/policyreports.yaml
+sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/policyreports.yaml
 
 # updatecli expects something in stdout when a change happened.
 echo "Changed!"


### PR DESCRIPTION
## Description

Updates the script used to install the CRDs to add a if statement in the files updated adding a if statement to allow users to skip CRDs installation based on the `installPolicyReportCRDs` configuration.

