### PR TITLE
feat: support policy-optimizer

### DIFF
--- a/charts/kubewarden-defaults/templates/policy-server-rbac.yaml
+++ b/charts/kubewarden-defaults/templates/policy-server-rbac.yaml
@@ -46,3 +46,60 @@ roleRef:
   kind: ClusterRole
   name: kubewarden-context-watcher
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: policy-optimizer-leader-election-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubewarden-defaults.labels" . | nindent 4 }}
+    app.kubernetes.io/component: policy-server
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: policy-optimizer-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubewarden-defaults.labels" . | nindent 4 }}
+    app.kubernetes.io/component: policy-server
+  annotations:
+    {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: policy-optimizer-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.policyServer.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+


### PR DESCRIPTION
Extend the RBAC roles assigned to the `policy-server` Service Account.
Grant access to the resources required by `policy-optimizer`.

This is required to implement [this RFC](https://github.com/kubewarden/rfc/blob/main/rfc/0017-policy-server-reuse-wasm-optimized-modules.md).

More work has to be done, that's why this is a draft PR filed against a feature branch
