### PR TITLE
Allows more customisation to audit-scanner

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -111,7 +111,5 @@ auditScanner:
   # Additional namespaces that the audit scanner will not scan:
   skipAdditionalNamespaces: []
   logLevel: info
-  # File path to CA cert in PEM format of PolicyServer endpoints
-  policyServerCa: "/pki/policy-server-root-ca-pem"
-  # Prints the result of scan in JSON to stdout
-  enableJsonReport: true
+  # Output result of scan to stdout in JSON upon completion
+  outputScan: true

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -110,3 +110,8 @@ auditScanner:
   containerRestartPolicy: Never
   # Additional namespaces that the audit scanner will not scan:
   skipAdditionalNamespaces: []
+  logLevel: info
+  # File path to CA cert in PEM format of PolicyServer endpoints
+  policyServerCa: "/pki/policy-server-root-ca-pem"
+  # Prints the result of scan in JSON to stdout
+  enableJsonReport: true

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -110,6 +110,7 @@ auditScanner:
   containerRestartPolicy: Never
   # Additional namespaces that the audit scanner will not scan:
   skipAdditionalNamespaces: []
+  # level of logs. One of trace, debug, info, warn, error, fatal
   logLevel: info
   # Output result of scan to stdout in JSON upon completion
   outputScan: true

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -104,9 +104,9 @@ Create the name of the service account to use for kubewarden-controller
 - --loglevel
 - {{- .Values.auditScanner.logLevel }}
 - --extra-ca
-- {{- .Values.auditScanner.policyServerCa }}
-{{- if .Values.auditScanner.enableJsonReport }}
-- --print
+- "/pki/policy-server-root-ca-pem"
+{{- if .Values.auditScanner.outputScan }}
+- --output-scan
 {{- end }}
 {{- range .Values.global.skipNamespaces }}
 - {{ printf "-i" }}

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -99,10 +99,15 @@ Create the name of the service account to use for kubewarden-controller
 
 {{- define "audit-scanner.command" -}}
 - /audit-scanner
+- --kubewarden-namespace
+- {{ .Release.Namespace }}
 - --loglevel
-- info
+- {{- .Values.auditScanner.logLevel }}
 - --extra-ca
-- "/pki/policy-server-root-ca-pem"
+- {{- .Values.auditScanner.policyServerCa }}
+{{- if .Values.auditScanner.enableJsonReport }}
+- --print
+{{- end }}
 {{- range .Values.global.skipNamespaces }}
 - {{ printf "-i" }}
 - {{ printf "%s" . }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -146,6 +146,7 @@ auditScanner:
   containerRestartPolicy: Never
   # Additional namespaces that the audit scanner will not scan:
   skipAdditionalNamespaces: []
+  # level of logs. One of trace, debug, info, warn, error, fatal
   logLevel: info
   # Output result of scan to stdout in JSON upon completion
   outputScan: true

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -146,3 +146,8 @@ auditScanner:
   containerRestartPolicy: Never
   # Additional namespaces that the audit scanner will not scan:
   skipAdditionalNamespaces: []
+  logLevel: info
+  # File path to CA cert in PEM format of PolicyServer endpoints
+  policyServerCa: "/pki/policy-server-root-ca-pem"
+  # Prints the result of scan in JSON to stdout
+  enableJsonReport: true

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -147,7 +147,5 @@ auditScanner:
   # Additional namespaces that the audit scanner will not scan:
   skipAdditionalNamespaces: []
   logLevel: info
-  # File path to CA cert in PEM format of PolicyServer endpoints
-  policyServerCa: "/pki/policy-server-root-ca-pem"
-  # Prints the result of scan in JSON to stdout
-  enableJsonReport: true
+  # Output result of scan to stdout in JSON upon completion
+  outputScan: true


### PR DESCRIPTION
## Description
After using audit-scanner, deployed using Helm chart `kubewarden-controller` 1.6.0-rc2, I've noticed that there are a couple of parameters that are available in `audit-scanner` binary that unfortunately we can't use during the chart installation. This commit tries to improve that.

## Additional Information

### Potential improvement

Please let me know if you agree with this change or if this isn't at all aligned with the vision that you have for `audit-scanner`. Thank you!
