### PR TITLE
fix: Ensure installation of PolicyReport CRDs if value is missing or set to "null"

### DIFF
--- a/charts/kubewarden-crds/templates/clusterpolicyreports.yaml
+++ b/charts/kubewarden-crds/templates/clusterpolicyreports.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installPolicyReportCRDs }}
+{{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/kubewarden-crds/templates/policyreports.yaml
+++ b/charts/kubewarden-crds/templates/policyreports.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installPolicyReportCRDs }}
+{{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
## Description

In the Rancher manager environment, an issue arises during updates of the kubewarden-crds chart where the "installPolicyReportCRDs" configuration is sometimes set to "null." This results in problems as the CRDs, which should be installed by default, are not deployed. To address this issue, we've enhanced the conditional logic to install the CRDs when the flag is explicitly set to true or when it is missing altogether.

Fix https://github.com/kubewarden/kubewarden-controller/issues/515

