### PR TITLE
fix: wrong if statement to install policy report CRDs.

### DIFF
--- a/updatecli/scripts/install_crds.sh
+++ b/updatecli/scripts/install_crds.sh
@@ -9,9 +9,9 @@ tar -xvf /tmp/crds-audit-scanner.tar.gz
 find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
 find . -maxdepth 1 -name "*_policyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
 # add the if statement to allow users to skip the reports CRDs installation
-sed -i '1 i {{- if .Values.installPolicyReportCRDs }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
+sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
 sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
-sed -i '1 i {{- if .Values.installPolicyReportCRDs }}' charts/kubewarden-crds/templates/policyreports.yaml
+sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/policyreports.yaml
 sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/policyreports.yaml
 
 # updatecli expects something in stdout when a change happened.


### PR DESCRIPTION
## Description

The install_crds.sh script used by updatecli to install new version of     the CRDs is missing a logic clause in the if statement to check if the  policy report CRDs should be installed. This commit fixed that by adding the missing "or" logic.

