### PR TITLE
fix: CI should do the same changes in the policy reporter.

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -284,9 +284,9 @@ jobs:
           find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
           find . -maxdepth 1 -name "*_policyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
           # add the if statement to allow users to skip the reports CRDs installation
-          sed -i '1 i {{- if .Values.installPolicyReportCRDs }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
+          sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
           sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
-          sed -i '1 i {{- if .Values.installPolicyReportCRDs }}' charts/kubewarden-crds/templates/policyreports.yaml
+          sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/policyreports.yaml
           sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/policyreports.yaml
 
           set +e


### PR DESCRIPTION
## Description

The CI step to check if there is some CRDs update is doing the same done in the script to install the CRDs. Therefore, the CI could detect an update that does not exist. This commit fixes that by updating the `sed` commands used to manipulate some files.

