### PR TITLE
fix: kubewarden defaults post installation message

### DIFF
--- a/charts/kubewarden-defaults/templates/NOTES.txt
+++ b/charts/kubewarden-defaults/templates/NOTES.txt
@@ -1,7 +1,7 @@
 You now have a `PolicyServer` named `default` running in your cluster.
 It is ready to run any `clusteradmissionpolicies.policies.kubewarden.io` or
 `admissionpolicies.policies.kubewarden.io` resources.
-{{ if .Values.recommendedPolicies }}
+{{ if .Values.recommendedPolicies.enabled }}
 Installed recommended policies:
 - {{ .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.name }}
   module: {{ .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module }}

--- a/charts/kubewarden-defaults/templates/NOTES.txt
+++ b/charts/kubewarden-defaults/templates/NOTES.txt
@@ -15,6 +15,10 @@ Installed recommended policies:
   module: {{ .Values.recommendedPolicies.hostPathsPolicy.module }}
 - {{ .Values.recommendedPolicies.capabilitiesPolicy.name }}
   module: {{ .Values.recommendedPolicies.capabilitiesPolicy.module }}
+
+Note: all these policies have been installed in `monitor` mode, you can enforce them
+by changing their `mode` to `protect`.
+
 {{- end }}
 
 For more information check out https://docs.kubewarden.io/quick-start.


### PR DESCRIPTION
Inform the user about the policies that have been installed by the kubewarden-defaults chart only when the `recommendedPolicies.enabled` is set to `True` (which is not the default).

Also, make sure the user knows the default policies are deployed using the `monitor` mode.
