### PR TITLE
chore: bump version of kubewarden-defaults

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -20,7 +20,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.7.1
 # This is the version of Kubewarden stack
 appVersion: v1.7.0
 annotations:
@@ -34,7 +34,7 @@ annotations:
   # optional ones:
   catalog.cattle.io/hidden: true # Hide specific charts. Only use on CRD charts.
   catalog.cattle.io/auto-install: kubewarden-crds=1.4.0
-  catalog.cattle.io/upstream-version: 1.7.0
+  catalog.cattle.io/upstream-version: 1.7.1
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool


### PR DESCRIPTION
Perform a new release of the kubewarden-defaults chart to include https://github.com/kubewarden/helm-charts/pull/299
