### PR TITLE
ci: Make update_crds step conditional 

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -124,14 +124,19 @@ jobs:
           # The next commands are use in the updatecli/scripts/install_crds.sh as well.
           # Here the commands are used to detect CRDs changes. In the script they are used
           # to install the CRDs
-          tar -xvf /tmp/crds-controller.tar.gz
-          find . -maxdepth 1 -name "*_policyserver*" -exec  mv \{\} charts/kubewarden-crds/templates/policyservers.yaml \;
-          find . -maxdepth 1 -name "*_admissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/admissionpolicies.yaml \;
-          find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
 
-          tar -xvf /tmp/crds-audit-scanner.tar.gz
-          find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
-          find . -maxdepth 1 -name "*_policyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
+          if [ -f "/tmp/crds-controller.tar.gz" ]; then
+            tar -xvf /tmp/crds-controller.tar.gz
+            find . -maxdepth 1 -name "*_policyserver*" -exec  mv \{\} charts/kubewarden-crds/templates/policyservers.yaml \;
+            find . -maxdepth 1 -name "*_admissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/admissionpolicies.yaml \;
+            find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
+          fi
+
+          if [ -f "/tmp/crds-audit-scanner.tar.gz" ]; then
+            tar -xvf /tmp/crds-audit-scanner.tar.gz
+            find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
+            find . -maxdepth 1 -name "*_policyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
+          fi
 
           set +e
           git diff --exit-code --no-patch charts/kubewarden-crds
@@ -275,19 +280,24 @@ jobs:
           # The next commands are used in the updatecli/scripts/install_crds.sh as well.
           # Here the commands are used to detect CRDs changes. In the script they are used
           # to install the CRDs
-          tar -xvf /tmp/crds-controller.tar.gz
-          find . -maxdepth 1 -name "*_policyserver*" -exec  mv \{\} charts/kubewarden-crds/templates/policyservers.yaml \;
-          find . -maxdepth 1 -name "*_admissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/admissionpolicies.yaml \;
-          find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
 
-          tar -xvf /tmp/crds-audit-scanner.tar.gz
-          find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
-          find . -maxdepth 1 -name "*_policyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
-          # add the if statement to allow users to skip the reports CRDs installation
-          sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
-          sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
-          sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/policyreports.yaml
-          sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/policyreports.yaml
+          if [ -f "/tmp/crds-controller.tar.gz" ]; then
+            tar -xvf /tmp/crds-controller.tar.gz
+            find . -maxdepth 1 -name "*_policyserver*" -exec  mv \{\} charts/kubewarden-crds/templates/policyservers.yaml \;
+            find . -maxdepth 1 -name "*_admissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/admissionpolicies.yaml \;
+            find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
+          fi
+
+          if [ -f "/tmp/crds-audit-scanner.tar.gz" ]; then
+            tar -xvf /tmp/crds-audit-scanner.tar.gz
+            find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
+            find . -maxdepth 1 -name "*_policyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
+            # add the if statement to allow users to skip the reports CRDs installation
+            sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
+            sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
+            sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/policyreports.yaml
+            sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/policyreports.yaml
+          fi
 
           set +e
           git diff --exit-code --no-patch charts/kubewarden-crds

--- a/updatecli/scripts/install_crds.sh
+++ b/updatecli/scripts/install_crds.sh
@@ -1,18 +1,22 @@
 #!/bin/bash
 
-tar -xf /tmp/crds-controller.tar.gz
-find . -maxdepth 1 -name "*_policyserver*" -exec  mv \{\} /tmp/helm-charts/charts/kubewarden-crds/templates/policyservers.yaml \;
-find . -maxdepth 1 -name "*_admissionpolicies*" -exec  mv \{\} /tmp/helm-charts/charts/kubewarden-crds/templates/admissionpolicies.yaml \;
-find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec  mv \{\} /tmp/helm-charts/charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
+if [ -f "/tmp/crds-controller.tar.gz" ]; then
+	tar -xf /tmp/crds-controller.tar.gz
+	find . -maxdepth 1 -name "*_policyserver*" -exec mv \{\} /tmp/helm-charts/charts/kubewarden-crds/templates/policyservers.yaml \;
+	find . -maxdepth 1 -name "*_admissionpolicies*" -exec mv \{\} /tmp/helm-charts/charts/kubewarden-crds/templates/admissionpolicies.yaml \;
+	find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec mv \{\} /tmp/helm-charts/charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
+fi
 
-tar -xvf /tmp/crds-audit-scanner.tar.gz
-find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
-find . -maxdepth 1 -name "*_policyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
-# add the if statement to allow users to skip the reports CRDs installation
-sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
-sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
-sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/policyreports.yaml
-sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/policyreports.yaml
+if [ -f "/tmp/crds-audit-scanner.tar.gz" ]; then
+	tar -xvf /tmp/crds-audit-scanner.tar.gz
+	find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
+	find . -maxdepth 1 -name "*_policyreports*" -exec mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
+	# add the if statement to allow users to skip the reports CRDs installation
+	sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
+	sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
+	sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/policyreports.yaml
+	sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/policyreports.yaml
+fi
 
 # updatecli expects something in stdout when a change happened.
 echo "Changed!"


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Right now, the `update_crds` acts as if it had tar.gz for both
controller and audit-scanner crds. This makes it fail if the dispatched
job is only for 1 of those and not the other.

Fixes automated patch version PRs.
See for example how both of these jobs fail:
- https://github.com/kubewarden/helm-charts/actions/runs/6323127363/attempts/1 -> missing crds tar.gz for the audit-scanner, as this is the controller.
- https://github.com/kubewarden/helm-charts/actions/runs/6324807827 -> missing crds tar.gz for the controller, as this is the audit-scanner.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Untested.

Relates to https://github.com/kubewarden/kubewarden-controller/issues/534.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
