### PR TITLE
Revert "chore(deps): update all non-major dependencies"

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -143,7 +143,7 @@ jobs:
           echo "must_update_crds_chart=$?" >> $GITHUB_OUTPUT
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@df9eb45c5cb7f414b303dce6c74fcad1c0e10c5a # v2.41.0
+        uses: updatecli/updatecli-action@e0a352905ddb198fc7b068935133776c646465f9 # v2.39.0
 
       - name: Update kubewarden-defaults Helm chart
         if: endsWith(github.event.client_payload.repository, 'policy-server')
@@ -304,7 +304,7 @@ jobs:
           echo "must_update_crds_chart=$?" >> $GITHUB_OUTPUT
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@df9eb45c5cb7f414b303dce6c74fcad1c0e10c5a # v2.41.0
+        uses: updatecli/updatecli-action@e0a352905ddb198fc7b068935133776c646465f9 # v2.39.0
 
       - name: Major or minor update Kubewarden charts with NO CRDs update
         if: steps.update_crds.outputs.must_update_crds_chart==0 &&  (needs.check-update-type.outputs.update_type == 'major' || needs.check-update-type.outputs.update_type == 'minor')

--- a/charts/kubewarden-controller/Chart.lock
+++ b/charts/kubewarden-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: policy-reporter
   repository: https://kyverno.github.io/policy-reporter
-  version: 2.20.0
-digest: sha256:986e100cce6014bc25153a1a79ea056db79ef4c497156fe32e5234cbef6f24b0
-generated: "2023-09-21T13:52:14.29064067Z"
+  version: 2.19.4
+digest: sha256:145d113d1448d3c2217db65df2c2bc6ec91ba57ef9cbdb69805c2466187dbaba
+generated: "2023-09-05T09:47:29.471541497-03:00"

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -46,6 +46,6 @@ annotations:
   catalog.cattle.io/type: cluster-tool
 dependencies:
   - name: policy-reporter
-    version: 2.20.0
+    version: 2.19.4
     repository: https://kyverno.github.io/policy-reporter
     condition: auditScanner.policyReporter

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -121,10 +121,10 @@ policy-reporter:
   image:
     registry: ghcr.io
     repository: kyverno/policy-reporter
-    tag: 2.16.0
+    tag: 2.15.4
   ui:
     enabled: true
     image:
       registry: ghcr.io
       repository: kyverno/policy-reporter-ui
-      tag: 1.15.1
+      tag: 1.8.4

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -162,10 +162,10 @@ policy-reporter:
   image:
     registry: ghcr.io
     repository: kyverno/policy-reporter
-    tag: 2.16.0
+    tag: 2.15.4
   ui:
     enabled: true
     image:
       registry: ghcr.io
       repository: kyverno/policy-reporter-ui
-      tag: 1.15.1
+      tag: 1.8.4


### PR DESCRIPTION
Reverts kubewarden/helm-charts#294


That PR merged a bot bump of policy-reporter-ui, where it got bumped to `v1.15.1`.
Turns out that `1.15.1` tag is 2 years old, and looks like a mistake on tagging, as it is between `0.15.0` and `0.15.1` in the timeline. See:
https://github.com/orgs/kyverno/packages/container/policy-reporter-ui/10126783?tag=1.15.1