### PR TITLE
ci: Ignore policy-reporter-ui image 1.15.1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,4 +8,12 @@
   "labels": [
     "dependencies"
   ]
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "^policy-reporter-ui"
+      ],
+      "allowedVersions": "!/1.15.1$/"
+    }
+  ]
 }


### PR DESCRIPTION
## Description

On #294, the bot bumped of policy-reporter-ui, where it got bumped to v1.15.1. Turns out that 1.15.1 tag is 2 years old, and looks like a mistake on tagging, as it is between 0.15.0 and 0.15.1 in the timeline. See: https://github.com/orgs/kyverno/packages/container/policy-reporter-ui/10126783?tag=1.15.1

Relates to https://github.com/kubewarden/helm-charts/issues/311.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Not tested. We should be able to notice it's working once we merge and retrigger renovate bot, not getting an update for the image.
<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
