### PR TITLE
feat: Add .Values.policyServer.telemetry to kubewarden-defaults

### DIFF
--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -29,6 +29,10 @@ policyServer:
   env:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info
+  telemetry:
+    # open-telemetry options
+    # enabling telemetry sets log format to otlp for the policy-server
+    enabled: False
   annotations: {}
   # imagePullSecret stores the secret name used to pull images from repositories.
   # The secret should be in the same namespace of the Policy Server

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -27,6 +27,10 @@ spec:
     - name: {{ .name | quote }}
       value: {{ .value | quote }}
     {{- end }}
+    {{- if .Values.policyServer.telemetry.enabled }}
+    - name: KUBEWARDEN_LOG_FMT
+      value: otlp
+    {{- end }}
   {{- end }}
 {{- end }}
   {{- if .Values.policyServer.imagePullSecret }}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -70,6 +70,10 @@ policyServer:
   env:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info
+  telemetry:
+    # open-telemetry options
+    # enabling telemetry sets log format to otlp for the policy-server
+    enabled: False
   annotations: {}
   # imagePullSecret stores the secret name used to pull images from repositories.
   # The secret should be in the same namespace of the Policy Server


### PR DESCRIPTION


## Description

Relates to https://github.com/kubewarden/helm-charts/issues/310.

Setting this to true will add the necesary `KUBEWARDEN_LOG_FMT` env var to the default PolicyServer, so it outputs telemetry in OTLP format.

This is needed because the kubewarden controller doesn't take care of reconciling this env var anymore, allowing users to fine tune it.

For this commit's case, the default PolicyServer, we are fine keeping the behaviour as it is.

Note that this is not backwards compatible, as
`.Values.policyServer.telemetry` defaults to `false`.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To be tested together with a new controller image.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
