### PR TITLE
feat!: Fine-grain config for metrics and tracing

### DIFF
--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -32,10 +32,11 @@ preDeleteHook:
     runAsNonRoot: true
 # open-telemetry options
 telemetry:
-  enabled: False
   metrics:
+    enabled: False
     port: 8080
   tracing:
+    enabled: False
     jaeger: {}
     # OTLP/Jaeger endpoint to send traces to
     # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:4317"

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -34,6 +34,7 @@ preDeleteHook:
 telemetry:
   metrics:
     enabled: false
+    # port of the prometheus exporter and PolicyServer metric service
     port: 8080
   tracing:
     enabled: false

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -33,10 +33,10 @@ preDeleteHook:
 # open-telemetry options
 telemetry:
   metrics:
-    enabled: False
+    enabled: false
     port: 8080
   tracing:
-    enabled: False
+    enabled: false
     jaeger: {}
     # OTLP/Jaeger endpoint to send traces to
     # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:4317"

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- range keys .Values.podAnnotations }}
         {{ . | quote }}: {{ get $.Values.podAnnotations . | quote}}
         {{- end }}
-        {{- if .Values.telemetry.enabled }}
+        {{- if or .Values.telemetry.metrics.enabled .Values.telemetry.tracing.enabled}}
         "sidecar.opentelemetry.io/inject": "true"
         {{- end }}
         {{- include "kubewarden-controller.annotations" . | nindent 8 }}
@@ -38,13 +38,16 @@ spec:
         {{- if .Values.global.policyServer.default.enabled }}
         - --default-policy-server={{ .Values.global.policyServer.default.name }}
         {{- end }}
-       {{- if .Values.telemetry.enabled }}
+       {{- if .Values.telemetry.metrics.enabled }}
         - --enable-metrics
+       {{- end }}
+       {{- if .Values.telemetry.tracing.enabled }}
+        - --enable-tracing
        {{- end }}
         - --always-accept-admission-reviews-on-deployments-namespace
         command:
         - /manager
-        {{- if .Values.telemetry.enabled }}
+        {{- if .Values.telemetry.metrics.enabled }}
         env:
           - name: KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT
             value: "{{ .Values.telemetry.metrics.port | default 8080 }}"

--- a/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
+++ b/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.telemetry.enabled }}
+{{ if or .Values.telemetry.metrics.enabled .Values.telemetry.tracing.enabled }}
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
@@ -18,7 +18,7 @@ spec:
     processors:
       batch:
     exporters:
-      {{- if .Values.telemetry.tracing.jaeger.endpoint }}
+      {{- if and .Values.telemetry.tracing.enabled .Values.telemetry.tracing.jaeger.endpoint }}
       otlp/jaeger:
         endpoint: {{ .Values.telemetry.tracing.jaeger.endpoint }}
         {{- if hasKey .Values.telemetry.tracing.jaeger "tls" }}
@@ -28,25 +28,19 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if .Values.telemetry.metrics.port }}
+      {{- if and .Values.telemetry.metrics.enabled .Values.telemetry.metrics.port }}
       prometheus:
         endpoint: ":{{ .Values.telemetry.metrics.port }}"
       {{- end }}
     service:
       pipelines:
-        {{- if .Values.telemetry.metrics.port }}
+        {{- if and .Values.telemetry.metrics.enabled .Values.telemetry.metrics.port }}
         metrics:
           receivers: [otlp]
           processors: []
           exporters: [prometheus]
         {{- end }}
-        {{- if .Values.telemetry.tracing.jaeger.endpoint }}
-        traces:
-          receivers: [otlp]
-          processors: [batch]
-          exporters: [otlp/jaeger]
-        {{- end }}
-        {{- if .Values.telemetry.tracing.otlp_jaeger.endpoint }}
+        {{- if and .Values.telemetry.tracing.enabled .Values.telemetry.tracing.jaeger.endpoint }}
         traces:
           receivers: [otlp]
           processors: [batch]

--- a/charts/kubewarden-controller/templates/post-install-hook.yaml
+++ b/charts/kubewarden-controller/templates/post-install-hook.yaml
@@ -3,7 +3,7 @@
 # pod, it cannot find a valid collector configuration. Therefore, it is necessary
 # to recreate the controller pod after the installation. This ensures that the
 # controller pod will have the OTEL collector container.
-{{ if .Values.telemetry.enabled }}
+{{ if or .Values.telemetry.metrics.enabled .Values.telemetry.tracing.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/kubewarden-controller/templates/service.yaml
+++ b/charts/kubewarden-controller/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 spec:
   ports:
-  {{- if .Values.telemetry.enabled }}
+  {{- if .Values.telemetry.metrics.enabled }}
   - name: metrics
     port: 8080
     targetPort: 8080

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -73,10 +73,11 @@ preDeleteHook:
     runAsNonRoot: true
 # open-telemetry options
 telemetry:
-  enabled: False
   metrics:
+    enabled: False
     port: 8080
   tracing:
+    enabled: False
     jaeger: {}
     # OTLP/Jaeger endpoint to send traces to
     # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:4317"

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -74,10 +74,10 @@ preDeleteHook:
 # open-telemetry options
 telemetry:
   metrics:
-    enabled: False
+    enabled: false
     port: 8080
   tracing:
-    enabled: False
+    enabled: false
     jaeger: {}
     # OTLP/Jaeger endpoint to send traces to
     # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:4317"

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -75,6 +75,7 @@ preDeleteHook:
 telemetry:
   metrics:
     enabled: false
+    # port of the prometheus exporter and PolicyServer metric service
     port: 8080
   tracing:
     enabled: false

--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -29,10 +29,6 @@ policyServer:
   env:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info
-  telemetry:
-    # open-telemetry options
-    # enabling telemetry sets log format to otlp for the policy-server
-    enabled: False
   annotations: {}
   # imagePullSecret stores the secret name used to pull images from repositories.
   # The secret should be in the same namespace of the Policy Server

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -27,10 +27,6 @@ spec:
     - name: {{ .name | quote }}
       value: {{ .value | quote }}
     {{- end }}
-    {{- if .Values.policyServer.telemetry.enabled }}
-    - name: KUBEWARDEN_LOG_FMT
-      value: otlp
-    {{- end }}
   {{- end }}
 {{- end }}
   {{- if .Values.policyServer.imagePullSecret }}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -70,10 +70,6 @@ policyServer:
   env:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info
-  telemetry:
-    # open-telemetry options
-    # enabling telemetry sets log format to otlp for the policy-server
-    enabled: False
   annotations: {}
   # imagePullSecret stores the secret name used to pull images from repositories.
   # The secret should be in the same namespace of the Policy Server


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/helm-charts/issues/310.

Now the kubewarden-controller image reconciles configuration of both
tracing and telemetry for PolicyServers. Configure it so.

Consume `telemetry.metrics.enabled` and `telemetry.tracing.enabled` for
the rest of cases, making configuration more fine graded. This should
result in cleaner OTLP collector and sidecar logs.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
E2E tests.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
