### PR TITLE
Update jaeger endpoint port in questions default value

### DIFF
--- a/charts/kubewarden-controller/questions.yaml
+++ b/charts/kubewarden-controller/questions.yaml
@@ -88,7 +88,7 @@ questions:
     subquestions:
       - variable: "telemetry.tracing.jaeger.endpoint"
         type: string
-        default: my-open-telemetry-collector.jaeger.svc.cluster.local:4137
+        default: my-open-telemetry-collector.jaeger.svc.cluster.local:4317
         label: Jaeger endpoint configuration
         description: |
           Configuration of the OTLP/Jaeger exporter


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Updates the port number in the default value for the `telemetry.tracing.jaeger.endpoint` question, as the otlp port needs to be `4317`.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
https://opentelemetry.io/blog/2023/jaeger-exporter-collector-migration/

