### PR TITLE
feat: Add `make check-common-values` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ generate-values:
 .PHONY: check-generated-values
 check-generated-values: generate-values
 	@sh -c 'git diff --exit-code charts || (echo; echo "There are chart differences that have to be checked in"; exit 1)'
+	
+.PHONY: check-common-values
+check-common-values:
+	@./scripts/check-common-values.sh
 
 .PHONY: generate-images-file
 generate-images-file:

--- a/scripts/check-common-values.sh
+++ b/scripts/check-common-values.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Check that there's no divergence between ./common-values.yaml, key `global`,
+# and the `global` key on the helm-chart values.yaml
+
+diff <(yq --sort-keys .global common-values.yaml) <(yq --sort-keys .global charts/kubewarden-controller/values.yaml) || (
+	echo
+	echo "kubewaden-controller values.yaml diverges from common-values.yaml"
+	exit 1
+)
+diff <(yq --sort-keys .global common-values.yaml) <(yq --sort-keys .global charts/kubewarden-defaults/values.yaml) || (
+	echo
+	echo "kubewaden-defaults values.yaml diverges from common-values.yaml"
+	exit 1
+)


### PR DESCRIPTION
## Description

This target diffs the contents of `./common-values.yaml` and `charts/*/chart-values.yaml` for the `global` key.

This is analogous to what `make check-generated-values` does, but without calling `make generated-values`, nor having an interim `./charts/foo/chart-values.yaml` file per chart.

This new target is intended to substitute `make check-generated-values` and to drop the `chart-values.yaml`. This will simplify contributions and automation.
<!-- Please provide the link to the GitHub issue you are addressing -->

## Test

Edit common-values.yaml, for example adding a `.global.foo` key with value `bar`:
```console
$ make check-common-values
8d7
<       "foo": "bar",

kubewaden-controller values.yaml diverges from common-values.yaml
make: *** [Makefile:23: check-common-values] Error 1
```
On unchanged, correct chart values.yaml, it succeeds.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
