### PR TITLE
fix: Add imagePullSecrets for pre-delete-hook-image, support both with name or not

### DIFF
--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -66,6 +66,21 @@ app.kubernetes.io/part-of: kubewarden
 {{- end }}
 
 {{/*
+Print the image pull secrets in the expected format (an array of objects with one possible field, "name").
+*/}}
+{{- define "imagePullSecrets" }}
+    {{- $imagePullSecrets := list }}
+    {{- range . }}
+        {{- if kindIs "string" . }}
+            {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+        {{- else }}
+            {{- $imagePullSecrets = append $imagePullSecrets . }}
+        {{- end }}
+    {{- end }}
+    {{- toYaml $imagePullSecrets }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "kubewarden-controller.selectorLabels" -}}

--- a/charts/kubewarden-controller/templates/audit-scanner.yaml
+++ b/charts/kubewarden-controller/templates/audit-scanner.yaml
@@ -22,9 +22,9 @@ spec:
           securityContext:
           {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.imagePullSecrets }}
+          {{- if .Values.imagePullSecrets }}
           imagePullSecrets:
-          {{- toYaml .Values.imagePullSecrets | nindent 12 }}
+          {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 12 }}
           {{- end }}
           restartPolicy: {{ .Values.auditScanner.containerRestartPolicy }}
           volumes:

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -25,9 +25,9 @@ spec:
       labels:
         {{- include "kubewarden-controller.labels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+      {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kubewarden-controller.serviceAccountName" . }}
       containers:

--- a/charts/kubewarden-controller/templates/pre-delete-hook.yaml
+++ b/charts/kubewarden-controller/templates/pre-delete-hook.yaml
@@ -29,6 +29,10 @@ spec:
       securityContext:
 {{ toYaml .Values.preDeleteHook.podSecurityContext | indent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: pre-delete-job
           image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'

--- a/charts/kubewarden-controller/templates/pre-delete-hook.yaml
+++ b/charts/kubewarden-controller/templates/pre-delete-hook.yaml
@@ -29,9 +29,9 @@ spec:
       securityContext:
 {{ toYaml .Values.preDeleteHook.podSecurityContext | indent 8 }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+      {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
         - name: pre-delete-job


### PR DESCRIPTION
## Description

Set imagePullSecrets for pre-delete-hook image.

The `kubewarden-controller` chart now accepts both:
`--set 'imagePullSecrets[0]=my-secret'`
`--set 'imagePullSecrets[0].name=my-secret'`

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
