### PR TITLE
feat: exposes `store` flag from `audit-scanner`

### DIFF
--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -117,6 +117,12 @@ auditScanner:
   logLevel: info
   # Output result of scan to stdout in JSON upon completion
   outputScan: true
+  # Configures where a (Cluster)PolicyReport is stored.
+  # Currently, it can be either:
+  #  - kubernetes: which will use Kubernetes/etcd
+  #  - memory: which will use in-memory cache. note that you may need to adjust
+  #    `resources.auditScanner` when using this store
+  store: "kubernetes"
 # Values to configure the policy reporter subchart enabled by the
 # auditScanner.policyReporter flag
 policy-reporter:

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -118,6 +118,8 @@ Create the name of the service account to use for kubewarden-controller
 - {{ .Release.Namespace }}
 - --loglevel
 - {{ .Values.auditScanner.logLevel }}
+- --store
+- {{ .Values.auditScanner.store }}
 - --extra-ca
 - "/pki/policy-server-root-ca-pem"
 {{- if .Values.auditScanner.outputScan }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -168,6 +168,12 @@ auditScanner:
   logLevel: info
   # Output result of scan to stdout in JSON upon completion
   outputScan: true
+  # Configures where a (Cluster)PolicyReport is stored.
+  # Currently, it can be either:
+  #  - kubernetes: which will use Kubernetes/etcd
+  #  - memory: which will use in-memory cache. note that you may need to adjust
+  #    `resources.auditScanner` when using this store
+  store: "kubernetes"
 # Values to configure the policy reporter subchart enabled by the
 # auditScanner.policyReporter flag
 policy-reporter:


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix [#107](https://github.com/kubewarden/audit-scanner/issues/107)

As required by https://github.com/kubewarden/audit-scanner/issues/107, this commit adds the new flag - `store` - to the `kuberwarden-controller` Helm chart.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally using `helm template charts/kubewarden-controller`

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
