### PR TITLE
feat: Include `securityContexts` Kubewarden-defaults Helm chart for Policy Servers

### DIFF
--- a/charts/kubewarden-defaults/chart-values.yaml
+++ b/charts/kubewarden-defaults/chart-values.yaml
@@ -30,6 +30,8 @@ policyServer:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info
   annotations: {}
+  # follows the format of https://docs.kubewarden.io/operator-manual/CRDs#policyserversecurity
+  securityContexts: {}
   # imagePullSecret stores the secret name used to pull images from repositories.
   # The secret should be in the same namespace of the Policy Server
   #

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -28,7 +28,6 @@ spec:
       value: {{ .value | quote }}
     {{- end }}
   {{- end }}
-{{- end }}
   {{- if .Values.policyServer.imagePullSecret }}
   imagePullSecret: {{ .Values.policyServer.imagePullSecret | quote }}
   {{- end }}
@@ -49,3 +48,9 @@ spec:
   {{- end }}
   {{- end }}
   {{- end }}
+  {{- if .Values.policyServer.securityContexts }}
+  securityContexts: {{ toYaml .Values.policyServer.securityContexts | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -81,6 +81,8 @@ policyServer:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info
   annotations: {}
+  # follows the format of https://docs.kubewarden.io/operator-manual/CRDs#policyserversecurity
+  securityContexts: {}
   # imagePullSecret stores the secret name used to pull images from repositories.
   # The secret should be in the same namespace of the Policy Server
   #


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Ability configure the `securityContexts` from the PolicyServer Custom resource through the kubewarden-defaults Helm chart

I also found that the `{{- end }}` directive for `{{- if .Values.global.policyServer.default.enabled }}` was being closed too soon, making some values of the definition leak even if the policyServer is disabled

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
The format follows the CRD definition https://docs.kubewarden.io/operator-manual/CRDs#policyserversecurity

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

1. Go to the [chart-values.yaml](https://github.com/kubewarden/helm-charts/blob/main/charts/kubewarden-defaults/chart-values.yaml) and replace

```yaml
securityContexts: {}
```

with

```yaml
securityContexts:
  pod:
    runAsNonRoot: true
```

2. Execute on the root of the repo

```shell
make generate-values
helm template charts/kubewarden-defaults
```

3. The `helm template` command will output all created resources and you will be able to check that 

```yaml
securityContexts:
  pod:
    runAsNonRoot: true
```

is part of the PolicyServer resource definition

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
