### PR TITLE
fix: Disable logs tab on policy-reporter UI

### DIFF
--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -130,3 +130,5 @@ policy-reporter:
       registry: ghcr.io
       repository: kyverno/policy-reporter-ui
       tag: 1.9.1
+    views:
+      logs: false

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -181,3 +181,5 @@ policy-reporter:
       registry: ghcr.io
       repository: kyverno/policy-reporter-ui
       tag: 1.9.1
+    views:
+      logs: false


### PR DESCRIPTION
## Description

The Policy Reporter UI logs tab shows logs for enabled targets. Possible targets:
  https://kyverno.github.io/policy-reporter/core/targets/

This is configured by enabling the logs view, and setting `policy-reporter.ui.sources[]` value.

The log tab will be empty by default though, which can be disorienting. Disabling it.



<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
