### PR TITLE
fix: mutating policies targets pod only.

### DIFF
--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -19,18 +19,6 @@ spec:
       apiVersions: ["v1"]
       resources: ["pods"]
       operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
-    - apiGroups: [""]
-      apiVersions: ["v1"]
-      resources: ["replicationcontrollers"]
-      operations: ["CREATE", "UPDATE"]
-    - apiGroups: ["apps"]
-      apiVersions: ["v1"]
-      resources: ["deployments","replicasets","statefulsets","daemonsets"]
-      operations: ["CREATE", "UPDATE"]
-    - apiGroups: ["batch"]
-      apiVersions: ["v1"]
-      resources: ["jobs","cronjobs"]
-      operations: ["CREATE", "UPDATE"]
   mutating: true
   settings:
     default_allow_privilege_escalation: false

--- a/charts/kubewarden-defaults/templates/user-group-policy.yaml
+++ b/charts/kubewarden-defaults/templates/user-group-policy.yaml
@@ -19,18 +19,6 @@ spec:
       apiVersions: ["v1"]
       resources: ["pods"]
       operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
-    - apiGroups: [""]
-      apiVersions: ["v1"]
-      resources: ["replicationcontrollers"]
-      operations: ["CREATE", "UPDATE"]
-    - apiGroups: ["apps"]
-      apiVersions: ["v1"]
-      resources: ["deployments","replicasets","statefulsets","daemonsets"]
-      operations: ["CREATE", "UPDATE"]
-    - apiGroups: ["batch"]
-      apiVersions: ["v1"]
-      resources: ["jobs","cronjobs"]
-      operations: ["CREATE", "UPDATE"]
   mutating: true
   settings:
     run_as_user:


### PR DESCRIPTION
## Description

Updates the mutating policies to target pod resources only. This avoid reconciliation issues of higher level resources managed by other controllers.

Fix https://github.com/kubewarden/helm-charts/issues/374
