### PR TITLE
chore(deps): Bump controller image to `v1.10.1`, release kubewarden-controller `2.0.7`

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.6
+version: 2.0.7
 # This is the version of Kubewarden stack
 appVersion: v1.10.0
 annotations:
@@ -42,7 +42,7 @@ annotations:
   catalog.cattle.io/requests-cpu: "250m"
   catalog.cattle.io/requests-memory: "50Mi"
   catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.8.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
-  catalog.cattle.io/upstream-version: 2.0.6
+  catalog.cattle.io/upstream-version: 2.0.7
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-controller/chart-values.yaml
+++ b/charts/kubewarden-controller/chart-values.yaml
@@ -48,7 +48,7 @@ image:
   # controller image to be used
   repository: "kubewarden/kubewarden-controller"
   # image tag
-  tag: v1.10.0
+  tag: v1.10.1
   pullPolicy: IfNotPresent
 preDeleteJob:
   image:

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -99,7 +99,7 @@ image:
   # controller image to be used
   repository: "kubewarden/kubewarden-controller"
   # image tag
-  tag: v1.10.0
+  tag: v1.10.1
   pullPolicy: IfNotPresent
 preDeleteJob:
   image:


### PR DESCRIPTION
## Description

Image `kubewarden-controller:v1.10.1` contains a bump of `github.com/opencontainers/runc` to `v1.1.12`. runc is a dev dependency used in integration tests, and while we are not affected, previous versions are vulnerable to CVE-2024-21626.

This image bump makes the image scan clean.


## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
