### PR TITLE
refactor: Drop `make check-generated-values`, use `make check-common-values`

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -52,9 +52,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Check Helm generated values are up-to-date before releasing
+      - name: Check that the contents of common-values.yaml are included in values.yaml
         run: |
-          make check-generated-values
+          make check-common-values
 
       - name: Install Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to  https://github.com/kubewarden/helm-charts/issues/362

Leftover from https://github.com/kubewarden/helm-charts/issues/362

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI. This should make the release workflow work again in main (even if chart-releaser correctly sees there's nothing new to release).

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
