### PR TITLE
Prevent Policy Server Crash in case of a maintenance in Kubernetes Nodepools

### DIFF
--- a/charts/kubewarden-defaults/templates/poddisruptionbudget.yaml
+++ b/charts/kubewarden-defaults/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+    name: kubewarden-policy-server
+    namespace: {{ .Release.Namespace }}
+    annotations:
+      {{- include "kubewarden-defaults.annotations" . | nindent 6 }}
+    labels:
+      {{- include "kubewarden-defaults.labels" . | nindent 6 }}
+spec:
+  minAvailable: {{ sub .Values.policyServer.replicaCount 1 }}
+  selector:
+    matchLabels:
+      app: kubewarden-policy-server-default

--- a/charts/kubewarden-defaults/values.schema.json
+++ b/charts/kubewarden-defaults/values.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "required": ["policyServer"],
+  "properties": {
+    "policyServer": {
+      "type": "object",
+      "properties": {
+        "replicaCount": {
+          "type": "number",
+          "description": "Replica count of policyServer should be greater than 1",
+          "exclusiveMinimum": 1
+        }
+      }
+    }
+  }
+}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -57,7 +57,7 @@ additionalAnnotations: {}
 # owner: IT-group1
 # Policy Server settings
 policyServer:
-  replicaCount: 1
+  replicaCount: 2
   image:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     repository: "kubewarden/policy-server"


### PR DESCRIPTION
## Description

If policy server crash because of wrong clusteradmissionpolicy it is blocking pod to be created and cannot evaluate resources correctly. which is affecting control plane. therefore need to keep policy-server always available. These changes also can be added to policy server deployment but since it is hardcoded with Go, I thought of editing the helm chart.