### PR TITLE
fix!: Default to auditScanner.outputScan=false

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.7
+version: 2.0.8
 # This is the version of Kubewarden stack
 appVersion: v1.10.0
 annotations:
@@ -42,7 +42,7 @@ annotations:
   catalog.cattle.io/requests-cpu: "250m"
   catalog.cattle.io/requests-memory: "50Mi"
   catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.8.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
-  catalog.cattle.io/upstream-version: 2.0.7
+  catalog.cattle.io/upstream-version: 2.0.8
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -167,7 +167,7 @@ auditScanner:
   # level of logs. One of trace, debug, info, warn, error, fatal
   logLevel: info
   # Output result of scan to stdout in JSON upon completion
-  outputScan: true
+  outputScan: false
   # Configures where a (Cluster)PolicyReport is stored.
   # Currently, it can be either:
   #  - kubernetes: which will use Kubernetes/etcd


### PR DESCRIPTION
## Description

For big clusters with big (Cluster)PolicyReports, it is cost-prohibitive to print them as `info` logs in the auditScanner Jobs.

Change `auditScanner.outputScan` as opt-in, with false as default.

Bump kubewarden-controller chart to version `2.0.8`.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

## Additional Information

This is a breaking change. I have considered shipping it as a minor release instead and I am undecided. Nevertheless, it should be documented in changelog and notified.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
