### PR TITLE
fix: increase audit scanner memory limits

### DIFF
--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -136,10 +136,10 @@ resources:
   auditScanner:
     limits:
       cpu: 500m
-      memory: 50Mi
+      memory: 300Mi
     requests:
       cpu: 250m
-      memory: 50Mi
+      memory: 1Gi
 # Controller replicas
 replicas: 1
 auditScanner:


### PR DESCRIPTION
## Description

Increases audti scanner memory limits value used by the CronJob
