### PR TITLE
fix(ci): fix broken updatecli yaml files.

### DIFF
--- a/updatecli/updatecli.d/major-kubewarden-update.yaml
+++ b/updatecli/updatecli.d/major-kubewarden-update.yaml
@@ -10,27 +10,27 @@ sources:
       - trimsuffix: " "
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: "version"
+      key: "$.version"
 
   defaultChartAppVersion:
     name: Load chart app version
     kind: yaml
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: "appVersion"
+      key: "$.appVersion"
 
   defaultValuesFile:
     kind: yaml
     spec:
       file: "charts/kubewarden-defaults/values.yaml"
-      key: "policyServer.image.tag"
+      key: "$.policyServer.image.tag"
 
   controllerChartAppVersion:
     name: Load chart app version
     kind: yaml
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: "appVersion"
+      key: "$.appVersion"
 
   controllerChartVersion:
     name: Load controller chart version
@@ -41,19 +41,19 @@ sources:
       - trimsuffix: " "
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: "version"
+      key: "$.version"
 
   controllerImageValuesFile:
     kind: yaml
     spec:
       file: "charts/kubewarden-controller/values.yaml"
-      key: "image.tag"
+      key: "$.image.tag"
 
   auditScannerImageValuesFile:
     kind: yaml
     spec:
       file: "charts/kubewarden-controller/values.yaml"
-      key: "auditScanner.image.tag"
+      key: "$.auditScanner.image.tag"
 
 conditions:
   # All the major components must have the same tag
@@ -94,6 +94,7 @@ conditions:
         kind: "semver"
         pattern: "{{ requiredEnv .releaseVersion }}"
 
+targets:
   defaultUpdateValuesFile:
     kind: yaml
     name: "Update container image in the values.yaml file"
@@ -101,7 +102,7 @@ conditions:
     scmid: "default"
     spec:
       file: "charts/kubewarden-defaults/values.yaml"
-      key: "policyServer.image.tag"
+      key: "$.policyServer.image.tag"
       value: "{{ requiredEnv .releaseVersion }}"
 
   defaultChartVersionUpdate:
@@ -111,7 +112,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: "version"
+      key: "$.version"
 
   defaultChartVersionUpdate2:
     name: Bump defaults chart version in annotations
@@ -120,7 +121,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
+      key: "$.annotations.'catalog.cattle.io/upstream-version'"
 
   defaultChartAppVersionUpdate:
     name: Bump defaults chart app version
@@ -129,7 +130,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: "appVersion"
+      key: "$.appVersion"
       value: "{{ requiredEnv .releaseVersion }}"
 
   controllerImageUpdateValuesFile:
@@ -139,7 +140,7 @@ conditions:
     scmid: "default"
     spec:
       file: "charts/kubewarden-controller/values.yaml"
-      key: "image.tag"
+      key: "$.image.tag"
       value: "{{ requiredEnv .releaseVersion }}"
 
   controllerChartAppVersionUpdate:
@@ -149,7 +150,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: "appVersion"
+      key: "$.appVersion"
       value: "{{ requiredEnv .releaseVersion }}"
 
   auditScannerImageUpdateValuesFile:
@@ -159,7 +160,7 @@ conditions:
     scmid: "default"
     spec:
       file: "charts/kubewarden-controller/values.yaml"
-      key: "auditScanner.image.tag"
+      key: "$.auditScanner.image.tag"
       value: "{{ requiredEnv .releaseVersion }}"
 
   controllerChartVersionUpdate:
@@ -169,7 +170,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: "version"
+      key: "$.version"
 
   controllerChartVersionUpdate2:
     name: Bump controller chart version in annotations
@@ -178,7 +179,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
+      key: "$.annotations.'catalog.cattle.io/upstream-version'"
 
 actions:
   createUpdatePR:

--- a/updatecli/updatecli.d/prerelease-kubewarden-update.yaml
+++ b/updatecli/updatecli.d/prerelease-kubewarden-update.yaml
@@ -11,27 +11,27 @@ sources:
       - trimsuffix: " "
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: "version"
+      key: "$.version"
 
   defaultChartAppVersion:
     name: Load chart app version
     kind: yaml
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: "appVersion"
+      key: "$.appVersion"
 
   defaultValuesFile:
     kind: yaml
     spec:
       file: "charts/kubewarden-defaults/values.yaml"
-      key: "policyServer.image.tag"
+      key: "$.policyServer.image.tag"
 
   controllerChartAppVersion:
     name: Load chart app version
     kind: yaml
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: "appVersion"
+      key: "$.appVersion"
 
   controllerChartVersion:
     name: Load controller chart version
@@ -43,19 +43,19 @@ sources:
       - trimsuffix: " "
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: "version"
+      key: "$.version"
 
   controllerImageValuesFile:
     kind: yaml
     spec:
       file: "charts/kubewarden-controller/values.yaml"
-      key: "image.tag"
+      key: "$.image.tag"
 
   auditScannerImageValuesFile:
     kind: yaml
     spec:
       file: "charts/kubewarden-controller/values.yaml"
-      key: "auditScanner.image.tag"
+      key: "$.auditScanner.image.tag"
 
 conditions:
   # All the major components must have the same tag
@@ -96,6 +96,7 @@ conditions:
         kind: "semver"
         pattern: "{{ requiredEnv .releaseVersion }}"
 
+targets:
   defaultUpdateValuesFile:
     kind: yaml
     name: "Update container image in the values.yaml file"
@@ -103,7 +104,7 @@ conditions:
     scmid: "default"
     spec:
       file: "charts/kubewarden-defaults/values.yaml"
-      key: "policyServer.image.tag"
+      key: "$.policyServer.image.tag"
       value: "{{ requiredEnv .releaseVersion }}"
 
   defaultChartVersionUpdate:
@@ -113,7 +114,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: "version"
+      key: "$.version"
 
   defaultChartVersionUpdate2:
     name: Bump defaults chart version in annotations
@@ -122,7 +123,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
+      key: "$.annotations.'catalog.cattle.io/upstream-version'"
 
   defaultChartAppVersionUpdate:
     name: Bump defaults chart app version
@@ -131,7 +132,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: "appVersion"
+      key: "$.appVersion"
       value: "{{ requiredEnv .releaseVersion }}"
 
   controllerImageUpdateValuesFile:
@@ -141,7 +142,7 @@ conditions:
     scmid: "default"
     spec:
       file: "charts/kubewarden-controller/values.yaml"
-      key: "image.tag"
+      key: "$.image.tag"
       value: "{{ requiredEnv .releaseVersion }}"
 
   auditScannerImageUpdateValuesFile:
@@ -151,7 +152,7 @@ conditions:
     scmid: "default"
     spec:
       file: "charts/kubewarden-controller/values.yaml"
-      key: "auditScanner.image.tag"
+      key: "$.auditScanner.image.tag"
       value: "{{ requiredEnv .releaseVersion }}"
 
   controllerChartAppVersionUpdate:
@@ -161,7 +162,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: "appVersion"
+      key: "$.appVersion"
       value: "{{ requiredEnv .releaseVersion }}"
 
   controllerChartVersionUpdate:
@@ -171,7 +172,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: "version"
+      key: "$.version"
 
   controllerChartVersionUpdate2:
     name: Bump controller chart version in annotations
@@ -180,7 +181,7 @@ conditions:
     scmid: "default"
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
+      key: "$.annotations.'catalog.cattle.io/upstream-version'"
 
 actions:
   createUpdatePR:


### PR DESCRIPTION
## Description

There are two updatecli yaml files missing the `targets` field. Thus, the execution failed because all the update actions that should be under `targets` are children of the `conditions` field. This commit that adding the `targets` field.

This commit also fixes some warning messages from updatecli about the keys used to find the fields in the Helm chart yaml files.

This fix is required to tag `v1.11.0-rc1`. https://github.com/kubewarden/kubewarden-controller/issues/642