### PR TITLE
raise controller memory limits

### DIFF
--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -128,10 +128,10 @@ resources:
   controller:
     limits:
       cpu: 500m
-      memory: 50Mi
+      memory: 200Mi
     requests:
       cpu: 250m
-      memory: 50Mi
+      memory: 70Mi
   auditScanner:
     limits:
       cpu: 500m


### PR DESCRIPTION
Increase the amount of memory requested by the controller Pod and its limit.

Data is based on https://github.com/kubewarden/helm-charts/issues/157

Fixes https://github.com/kubewarden/helm-charts/issues/157
