### PR TITLE
fix: invalid audit scanner container command.

### DIFF
--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -118,8 +118,9 @@ Create the name of the service account to use for kubewarden-controller
 - {{ .Release.Namespace }}
 - --loglevel
 - {{ .Values.auditScanner.logLevel }}
+{{- if .Values.auditScanner.disableStore }}
 - --disable-store
-- {{ .Values.auditScanner.disableStore }}
+{{- end }}
 - --extra-ca
 - "/pki/policy-server-root-ca-pem"
 {{- if .Values.auditScanner.outputScan }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -135,10 +135,10 @@ resources:
   auditScanner:
     limits:
       cpu: 500m
-      memory: 300Mi
+      memory: 1Gi
     requests:
       cpu: 250m
-      memory: 1Gi
+      memory: 300Mi
 # Controller replicas
 replicas: 1
 auditScanner:


### PR DESCRIPTION
## Description

The container command is an array of strings. The `--disable-store` flag value passed is `false` which fails. Because it is unmarshaled as boolean. To fix that, the helper code to build the command must quote the boolean value

The memory resource configuration for the audit scanner is wrong. The limit is less then the requested amount. This  commit fixed that by inverting the quantities.


Fix #390 
