### PR TITLE
chore: kubewarden-crds version bump.

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -35,7 +35,7 @@ annotations:
   catalog.cattle.io/display-name: Kubewarden # Only for Charts with custom UI
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
-  catalog.cattle.io/auto-install: kubewarden-crds=1.4.5
+  catalog.cattle.io/auto-install: kubewarden-crds=1.4.6-rc1
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
   # The following two will create a UI warning if the request is not available in cluster
   # Assume the most standard setup for your chart. These can be strings with amounts, ie 64Mi or 2Gi are both valid.

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -22,9 +22,9 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.5
+version: 1.5.0-rc3
 # This is the version of Kubewarden stack
-appVersion: v1.10.0
+appVersion: v1.11.0-rc3
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0-rc3
+version: 1.4.6-rc1
 # This is the version of Kubewarden stack
 appVersion: v1.11.0-rc3
 annotations:
@@ -33,7 +33,7 @@ annotations:
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
   catalog.cattle.io/hidden: "true" # Hide specific charts. Only use on CRD charts.
-  catalog.cattle.io/upstream-version: 1.4.5
+  catalog.cattle.io/upstream-version: 1.4.6-rc1
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -36,7 +36,7 @@ annotations:
   # optional ones:
   catalog.cattle.io/hidden: "true" # Hide specific charts. Only use on CRD charts.
   catalog.cattle.io/upstream-version: 1.9.4-rc3
-  catalog.cattle.io/auto-install: kubewarden-crds=1.4.5
+  catalog.cattle.io/auto-install: kubewarden-crds=1.4.6-rc1
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool


### PR DESCRIPTION
## Description

Updates the appVersion of the kubewarden-crds chart to keep it in sync with the other charts. The version is now v1.11.0-rc3. The chart version also needs to be updated to release the chart.

Fix #395 
