### PR TITLE
ci: Add UI inputs for `Update helm charts` job, refactor and drop need for `crds_asset_id` 

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -9,19 +9,27 @@ on:
           Version of the release that triggered the workflow
         required: true
         type: string
+        default: v1.10.0
       oldVersion:
         description: |
           oldVersion:
           Previous version of the release, already shipped in helm-charts
         required: true
         type: string
+        default: v1.9.0
       repository:
         description: |
           repository:
           Repository of the release that triggered the workflow
         required: true
-        type: string
-        default: kubewarden/kubewarden-controller
+        # in case of developing, change to type string:
+        # type: string
+        type: choice
+        options:
+          - kubewarden/kubewarden-controller
+          - kubewarden/policy-server
+          - kubewarden/kwctl
+          - kubewarden/audit-scanner
 
   repository_dispatch:
     types: [update-chart]

--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -2,20 +2,46 @@ name: Update helm charts
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          version:
+          Version of the release that triggered the workflow
+        required: true
+        type: string
+      oldVersion:
+        description: |
+          oldVersion:
+          Previous version of the release, already shipped in helm-charts
+        required: true
+        type: string
+      repository:
+        description: |
+          repository:
+          Repository of the release that triggered the workflow
+        required: true
+        type: string
+        default: kubewarden/kubewarden-controller
+
   repository_dispatch:
     types: [update-chart]
 
 jobs:
-  check-update-type:
-    name: Detect update type
+  setvariables:
+    name: Read variables from dispatch
+    # read variables from either the repository_dispatch or the
+    # workflow_dispatch, and create job outputs to reuse in other jobs.
+    # It is not enough with env vars. We need job outputs, as they are shared
+    # between jobs, since each job runs in a different VM instance.
     runs-on: ubuntu-latest
     outputs:
-      update_type: ${{ steps.check_update_type.outputs.update_type }}
-      repository: ${{ steps.check_update_type.outputs.repository }}
-      prerelease: ${{ steps.check_update_type.outputs.prerelease }}
+      version: ${{ github.event_name == 'repository_dispatch' && steps.from_repository_dispatch.outputs.version || steps.from_workflow_dispatch.outputs.version }}
+      old_version: ${{ github.event_name == 'repository_dispatch' && steps.from_repository_dispatch.outputs.old_version || steps.from_workflow_dispatch.outputs.old_version }}
+      repository: ${{ github.event_name == 'repository_dispatch' && steps.from_repository_dispatch.outputs.repository || steps.from_workflow_dispatch.outputs.repository }}
     steps:
       - name: Validate payload
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: github.event_name == 'repository_dispatch'
         with:
           script: |
             let repository = context.payload.client_payload.repository
@@ -23,6 +49,31 @@ jobs:
                     core.setFailed("Invalid repository")
             }
 
+      - name: Set job output vars from repository_dispatch payload
+        id: from_repository_dispatch
+        if: github.event_name == 'repository_dispatch'
+        run: |
+          echo "old_version=${{ github.event.client_payload.oldVersion }}" >> $GITHUB_OUTPUT
+          echo "version=${{ github.event.client_payload.version }}" >> $GITHUB_OUTPUT
+          echo "repository=${{ github.event.client_payload.repository }}" >> $GITHUB_OUTPUT
+
+      - name: Set job output vars from workflow_dispatch input
+        id: from_workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "old_version=${{ inputs.oldVersion }}" >> $GITHUB_OUTPUT
+          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          echo "repository=${{ inputs.repository }}" >> $GITHUB_OUTPUT
+
+  check-update-type:
+    name: Detect update type
+    runs-on: ubuntu-latest
+    needs: setvariables
+    outputs:
+      update_type: ${{ steps.check_update_type.outputs.update_type }}
+      repository: ${{ steps.check_update_type.outputs.repository }}
+      prerelease: ${{ steps.check_update_type.outputs.prerelease }}
+    steps:
       - name: Install semver comparison tool
         run: |
           INSTALL_DIR=$HOME/.semver
@@ -34,9 +85,9 @@ jobs:
       - name: Check if it is a patch update
         id: check_update_type
         run: |
-          OLDVERSION=${{github.event.client_payload.oldVersion}}
-          NEWVERSION=${{github.event.client_payload.version}}
-          REPOSITORY=${{github.event.client_payload.repository}}
+          OLDVERSION=${{ needs.setvariables.outputs.old_version }}
+          NEWVERSION=${{ needs.setvariables.outputs.version }}
+          REPOSITORY=${{ needs.setvariables.outputs.repository }}
 
           VALID=$(semver validate $OLDVERSION)
           if [[ $VALID == "invalid" ]]; then
@@ -63,31 +114,40 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check-update-type
+      - setvariables
     if: needs.check-update-type.outputs.update_type == 'patch' && !endsWith(needs.check-update-type.outputs.repository, 'kwctl')
     permissions:
       contents: write
       pull-requests: write
     steps:
+      - name: create env vars from needs.setvariables.outputs
+        # This is neeeded because in scripts, we don't have a way to access the `needs` json object.
+        # The env vars defined here will be accesible in the scripts under `process.env.foo`
+        run: |
+          echo "old_version=${{ needs.setvariables.outputs.old_version }}" >> $GITHUB_ENV
+          echo "version=${{ needs.setvariables.outputs.version }}" >> $GITHUB_ENV
+          echo "repository=${{ needs.setvariables.outputs.repository }}" >> $GITHUB_ENV
+
       - name: Set environment variables
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             core.exportVariable("UPDATECLI_GITHUB_OWNER", context.repo["owner"])
-            core.exportVariable("UPDATECLI_CHART_VERSION", context.payload.client_payload.version)
+            core.exportVariable("UPDATECLI_CHART_VERSION", process.env.version )
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Download CRDS controller
-        if: endsWith(github.event.client_payload.repository, 'kubewarden-controller')
+        if: endsWith(needs.setvariables.outputs.repository, 'kubewarden-controller')
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            let repository = context.payload.client_payload.repository
+            let repository = process.env.repository
             if (repository.endsWith("kubewarden-controller")) {
-              let crds_asset_id = context.payload.client_payload.crds_asset_id
+              let crds_asset_id = process.env.crds_asset_id
               console.log(`Fetching asset ID: ${crds_asset_id}`)
-              let repository_split = context.payload.client_payload.repository.split("/")
+              let repository_split = repository.split("/")
               let owner = repository_split[0]
               let repository = repository_split[1]
               let asset = await github.rest.repos.getReleaseAsset({
@@ -99,15 +159,15 @@ jobs:
             }
 
       - name: Download CRDS audit-scanner
-        if: endsWith(github.event.client_payload.repository, 'audit-scanner')
+        if: endsWith(needs.setvariables.outputs.repository, 'audit-scanner')
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            let repository = context.payload.client_payload.repository
+            let repository = process.env.repository
             if (repository.endsWith("audit-scanner")) {
-              let crds_asset_id = context.payload.client_payload.crds_asset_id
+              let crds_asset_id = process.env.crds_asset_id
               console.log(`Fetching asset ID: ${crds_asset_id}`)
-              let repository_split = context.payload.client_payload.repository.split("/")
+              let repository_split = repository.split("/")
               let owner = repository_split[0]
               let repository = repository_split[1]
               let asset = await github.rest.repos.getReleaseAsset({
@@ -119,7 +179,7 @@ jobs:
             }
 
       - name: Update CRDs
-        if: endsWith(github.event.client_payload.repository, 'kubewarden-controller') || endsWith(github.event.client_payload.repository, 'audit-scanner')
+        if: endsWith(needs.setvariables.outputs.repository, 'kubewarden-controller') || endsWith(needs.setvariables.outputs.repository, 'audit-scanner')
         id: update_crds
         run: |
           # The next commands are use in the updatecli/scripts/install_crds.sh as well.
@@ -147,19 +207,19 @@ jobs:
         uses: updatecli/updatecli-action@ecfc21fd2d9e91be2af8b706ea10aea5154f6d5d # v2.54.0
 
       - name: Update kubewarden-defaults Helm chart
-        if: endsWith(github.event.client_payload.repository, 'policy-server')
+        if: endsWith(needs.setvariables.outputs.repository, 'policy-server')
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: "updatecli apply --config ./updatecli/updatecli.d/patch-kubewarden-defaults.yaml --values updatecli/values.yaml"
 
       - name: Update kubewarden-controller Helm chart with no CRDs update
-        if: (endsWith(github.event.client_payload.repository, 'kubewarden-controller') || endsWith(github.event.client_payload.repository, 'audit-scanner')) && steps.update_crds.outputs.must_update_crds_chart==0
+        if: (endsWith(needs.setvariables.outputs.repository, 'kubewarden-controller') || endsWith(needs.setvariables.outputs.repository, 'audit-scanner')) && steps.update_crds.outputs.must_update_crds_chart==0
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: "updatecli apply --config ./updatecli/updatecli.d/patch-kubewarden-controller.yaml --values updatecli/values.yaml"
 
       - name: Update kubewarden-controller Helm chart with CRDs update
-        if: (endsWith(github.event.client_payload.repository, 'kubewarden-controller') || endsWith(github.event.client_payload.repository, 'audit-scanner')) && steps.update_crds.outputs.must_update_crds_chart!=0
+        if: (endsWith(needs.setvariables.outputs.repository, 'kubewarden-controller') || endsWith(needs.setvariables.outputs.repository, 'audit-scanner')) && steps.update_crds.outputs.must_update_crds_chart!=0
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: "updatecli apply --config ./updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml --values updatecli/values.yaml"
@@ -169,8 +229,17 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check-update-type
+      - setvariables
     if: needs.check-update-type.outputs.update_type == 'major' || needs.check-update-type.outputs.update_type == 'minor' || needs.check-update-type.outputs.update_type == 'prerelease'
     steps:
+      - name: create env vars from needs.setvariables.outputs
+        # This is neeeded because in scripts, we don't have a way to access the `needs` json object.
+        # The env vars defined here will be accesible in the scripts under `process.env.foo`
+        run: |
+          echo "old_version=${{ needs.setvariables.outputs.old_version }}" >> $GITHUB_ENV
+          echo "version=${{ needs.setvariables.outputs.version }}" >> $GITHUB_ENV
+          echo "repository=${{ needs.setvariables.outputs.repository }}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -178,9 +247,9 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            let repository_split = context.payload.client_payload.repository.split("/")
+            let repository_split = process.env.repository.split("/")
             let owner = repository_split[0]
-            const version = context.payload.client_payload.version
+            const version = process.env.version
             let repos = ['kubewarden-controller', 'policy-server', 'kwctl', 'audit-scanner']
 
             for (const repo of repos) {
@@ -196,16 +265,16 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            let repository_split = context.payload.client_payload.repository.split("/")
+            let repository_split = process.env.repository.split("/")
             let owner = repository_split[0]
             let repository = repository_split[1]
             let crds_asset_id = null
             const controller_repo = "kubewarden-controller"
-            const version = context.payload.client_payload.version
+            const version = process.env.version
             const crds_tarball = "CRDS.tar.gz"
 
             if (repository === controller_repo) {
-              crds_asset_id = context.payload.client_payload.crds_asset_id
+              crds_asset_id = process.env.crds_asset_id
             } else {
               crds_asset_id = await github.rest.repos.getReleaseByTag({owner: owner, repo:  controller_repo, tag: version,}).then((response) => {
                   for (const file of response.data.assets) {
@@ -238,16 +307,16 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            let repository_split = context.payload.client_payload.repository.split("/")
+            let repository_split = process.env.repository.split("/")
             let owner = repository_split[0]
             let repository = repository_split[1]
             let crds_asset_id = null
             const audit_scanner_repo = "audit-scanner"
-            const version = context.payload.client_payload.version
+            const version = process.env.version
             const crds_tarball = "CRDS.tar.gz"
 
             if (repository === audit_scanner_repo) {
-              crds_asset_id = context.payload.client_payload.crds_asset_id
+              crds_asset_id = process.env.crds_asset_id
             } else {
               crds_asset_id = await github.rest.repos.getReleaseByTag({owner: owner, repo:  audit_scanner_repo, tag: version,}).then((response) => {
                   for (const file of response.data.assets) {
@@ -314,7 +383,7 @@ jobs:
           UPDATECLI_SEMVERINC_UPDATE: ${{ needs.check-update-type.outputs.update_type }}
           UPDATECLI_PRERELEASE_SUFFIX: ${{ needs.check-update-type.outputs.prerelease }}
           UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
-          UPDATECLI_CHART_VERSION: ${{ github.event.client_payload.version }}
+          UPDATECLI_CHART_VERSION: ${{ needs.setvariables.outputs.version }}
         run: "updatecli apply --config ./updatecli/updatecli.d/major-kubewarden-update.yaml --values updatecli/values.yaml"
 
       - name: Major or minor update Kubewarden charts WITH CRDs update
@@ -324,7 +393,7 @@ jobs:
           UPDATECLI_SEMVERINC_UPDATE: ${{ needs.check-update-type.outputs.update_type }}
           UPDATECLI_PRERELEASE_SUFFIX: ${{ needs.check-update-type.outputs.prerelease }}
           UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
-          UPDATECLI_CHART_VERSION: ${{ github.event.client_payload.version }}
+          UPDATECLI_CHART_VERSION: ${{ needs.setvariables.outputs.version }}
         run: "updatecli apply --config ./updatecli/updatecli.d/major-kubewarden-update-with-crd-update.yaml --values updatecli/values.yaml"
 
       - name: Prerelease update Kubewarden charts with NO CRDs update
@@ -334,7 +403,7 @@ jobs:
           UPDATECLI_SEMVERINC_UPDATE: ${{ needs.check-update-type.outputs.update_type }}
           UPDATECLI_PRERELEASE_SUFFIX: ${{ needs.check-update-type.outputs.prerelease }}
           UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
-          UPDATECLI_CHART_VERSION: ${{ github.event.client_payload.version }}
+          UPDATECLI_CHART_VERSION: ${{ needs.setvariables.outputs.version }}
         run: "updatecli apply --config ./updatecli/updatecli.d/prerelease-kubewarden-update.yaml --values updatecli/values.yaml"
 
       - name: Prerelease update Kubewarden charts WITH CRDs update
@@ -344,5 +413,5 @@ jobs:
           UPDATECLI_SEMVERINC_UPDATE: ${{ needs.check-update-type.outputs.update_type }}
           UPDATECLI_PRERELEASE_SUFFIX: ${{ needs.check-update-type.outputs.prerelease }}
           UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
-          UPDATECLI_CHART_VERSION: ${{ github.event.client_payload.version }}
+          UPDATECLI_CHART_VERSION: ${{ needs.setvariables.outputs.version }}
         run: "updatecli apply --config ./updatecli/updatecli.d/prerelease-kubewarden-update-with-crd-update.yaml --values updatecli/values.yaml"

--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -205,26 +205,12 @@ jobs:
         if: endsWith(needs.setvariables.outputs.repository, 'kubewarden-controller') || endsWith(needs.setvariables.outputs.repository, 'audit-scanner')
         id: update_crds
         run: |
-          # The next commands are use in the updatecli/scripts/install_crds.sh as well.
-          # Here the commands are used to detect CRDs changes. In the script they are used
-          # to install the CRDs
-
-          if [ -f "/tmp/crds-controller.tar.gz" ]; then
-            tar -xvf /tmp/crds-controller.tar.gz
-            find . -maxdepth 1 -name "*_policyserver*" -exec  mv \{\} charts/kubewarden-crds/templates/policyservers.yaml \;
-            find . -maxdepth 1 -name "*_admissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/admissionpolicies.yaml \;
-            find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
-          fi
-
-          if [ -f "/tmp/crds-audit-scanner.tar.gz" ]; then
-            tar -xvf /tmp/crds-audit-scanner.tar.gz
-            find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
-            find . -maxdepth 1 -name "*_policyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
-          fi
-
+          # Install CRDs from tar.gz, and then see if there was any change,
+          # which tells us if updatecli needs to bump the crds chart or not
+          ./updatecli/scripts/install_crds.sh
           set +e
           git diff --exit-code --no-patch charts/kubewarden-crds
-          echo "must_update_crds_chart=$?" >> $GITHUB_OUTPUT
+          echo "must_update_crds_chart=$?" >> "$GITHUB_OUTPUT"
 
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@ecfc21fd2d9e91be2af8b706ea10aea5154f6d5d # v2.54.0
@@ -362,31 +348,12 @@ jobs:
       - name: Update CRDS
         id: update_crds
         run: |
-          # The next commands are used in the updatecli/scripts/install_crds.sh as well.
-          # Here the commands are used to detect CRDs changes. In the script they are used
-          # to install the CRDs
-
-          if [ -f "/tmp/crds-controller.tar.gz" ]; then
-            tar -xvf /tmp/crds-controller.tar.gz
-            find . -maxdepth 1 -name "*_policyserver*" -exec  mv \{\} charts/kubewarden-crds/templates/policyservers.yaml \;
-            find . -maxdepth 1 -name "*_admissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/admissionpolicies.yaml \;
-            find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec  mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
-          fi
-
-          if [ -f "/tmp/crds-audit-scanner.tar.gz" ]; then
-            tar -xvf /tmp/crds-audit-scanner.tar.gz
-            find . -maxdepth 1 -name "*_clusterpolicyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/clusterpolicyreports.yaml \;
-            find . -maxdepth 1 -name "*_policyreports*" -exec  mv \{\} charts/kubewarden-crds/templates/policyreports.yaml \;
-            # add the if statement to allow users to skip the reports CRDs installation
-            sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
-            sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/clusterpolicyreports.yaml
-            sed -i '1 i {{- if or .Values.installPolicyReportCRDs (not (hasKey .Values "installPolicyReportCRDs")) }}' charts/kubewarden-crds/templates/policyreports.yaml
-            sed -i '$ a {{ end }}' charts/kubewarden-crds/templates/policyreports.yaml
-          fi
-
+          # Install CRDs from tar.gz, and then see if there was any change,
+          # which tells us if updatecli needs to bump the crds chart or not
+          ./updatecli/scripts/install_crds.sh
           set +e
           git diff --exit-code --no-patch charts/kubewarden-crds
-          echo "must_update_crds_chart=$?" >> $GITHUB_OUTPUT
+          echo "must_update_crds_chart=$?" >> "$GITHUB_OUTPUT"
 
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@ecfc21fd2d9e91be2af8b706ea10aea5154f6d5d # v2.54.0

--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -128,13 +128,6 @@ jobs:
           echo "version=${{ needs.setvariables.outputs.version }}" >> $GITHUB_ENV
           echo "repository=${{ needs.setvariables.outputs.repository }}" >> $GITHUB_ENV
 
-      - name: Set environment variables
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            core.exportVariable("UPDATECLI_GITHUB_OWNER", context.repo["owner"])
-            core.exportVariable("UPDATECLI_CHART_VERSION", process.env.version )
-
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -240,18 +233,24 @@ jobs:
         if: endsWith(needs.setvariables.outputs.repository, 'policy-server')
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+          UPDATECLI_CHART_VERSION: ${{ needs.setvariables.outputs.version }}
         run: "updatecli apply --config ./updatecli/updatecli.d/patch-kubewarden-defaults.yaml --values updatecli/values.yaml"
 
       - name: Update kubewarden-controller Helm chart with no CRDs update
         if: (endsWith(needs.setvariables.outputs.repository, 'kubewarden-controller') || endsWith(needs.setvariables.outputs.repository, 'audit-scanner')) && steps.update_crds.outputs.must_update_crds_chart==0
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+          UPDATECLI_CHART_VERSION: ${{ needs.setvariables.outputs.version }}
         run: "updatecli apply --config ./updatecli/updatecli.d/patch-kubewarden-controller.yaml --values updatecli/values.yaml"
 
       - name: Update kubewarden-controller Helm chart with CRDs update
         if: (endsWith(needs.setvariables.outputs.repository, 'kubewarden-controller') || endsWith(needs.setvariables.outputs.repository, 'audit-scanner')) && steps.update_crds.outputs.must_update_crds_chart!=0
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+          UPDATECLI_CHART_VERSION: ${{ needs.setvariables.outputs.version }}
         run: "updatecli apply --config ./updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml --values updatecli/values.yaml"
 
   major-minor-prerelease-update:

--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -143,40 +143,70 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            let repository = process.env.repository
-            if (repository.endsWith("kubewarden-controller")) {
-              let crds_asset_id = process.env.crds_asset_id
-              console.log(`Fetching asset ID: ${crds_asset_id}`)
-              let repository_split = repository.split("/")
-              let owner = repository_split[0]
-              let repository = repository_split[1]
-              let asset = await github.rest.repos.getReleaseAsset({
-                      owner: owner, repo: repository, asset_id: crds_asset_id, headers:{
-                              accept: "application/octet-stream"},
-              })
-              let fs = require('fs');
-              fs.writeFileSync("/tmp/crds-controller.tar.gz", Buffer.from(asset.data))
+            let repository_split = process.env.repository.split("/")
+            let owner = repository_split[0]
+            const repo = "kubewarden-controller"
+            const version = process.env.version
+            const crds_tarball = "CRDS.tar.gz"
+
+            console.log(`Obtaining GH asset id for ${crds_tarball} in ${process.env.repository}`)
+            let crds_asset_id = await github.rest.repos.getReleaseByTag({owner: owner, repo: repo, tag: version,}).then((response) => {
+              for (const file of response.data.assets) {
+                if (file.name == crds_tarball) {
+                  return file.id;
+                }
+              }
+              return null;
+            }, (failedResponse) => {
+              core.setFailed("Cannot obtain crds_assed_id, no matching CRDS.tar.gz found")
+            });
+            if (typeof(crds_asset_id) != "number") {
+              core.setFailed(`No ${crds_tarball} found. This is expected if the ${repo} release job is still running. Otherwise, check why the release in the controller does not contains the CRDs tarball`)
             }
+
+            console.log(`Fetching ${crds_tarball} asset with id: ${crds_asset_id}`)
+            let asset = await github.rest.repos.getReleaseAsset({
+                    owner: owner, repo: repo, asset_id: crds_asset_id, headers:{
+                            accept: "application/octet-stream"},
+            })
+            let fs = require('fs');
+            fs.writeFileSync("/tmp/crds-controller.tar.gz", Buffer.from(asset.data))
+            console.log(`${crds_tarball} downloaded successfully`)
 
       - name: Download CRDS audit-scanner
         if: endsWith(needs.setvariables.outputs.repository, 'audit-scanner')
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            let repository = process.env.repository
-            if (repository.endsWith("audit-scanner")) {
-              let crds_asset_id = process.env.crds_asset_id
-              console.log(`Fetching asset ID: ${crds_asset_id}`)
-              let repository_split = repository.split("/")
-              let owner = repository_split[0]
-              let repository = repository_split[1]
-              let asset = await github.rest.repos.getReleaseAsset({
-                      owner: owner, repo: repository, asset_id: crds_asset_id, headers:{
-                              accept: "application/octet-stream"},
-              })
-              let fs = require('fs');
-              fs.writeFileSync("/tmp/crds-audit-scanner.tar.gz", Buffer.from(asset.data))
+            let repository_split = process.env.repository.split("/")
+            let owner = repository_split[0]
+            const repo = "audit-scanner"
+            const version = process.env.version
+            const crds_tarball = "CRDS.tar.gz"
+
+            console.log(`Obtaining GH asset id for ${crds_tarball} in ${process.env.repository}`)
+            let crds_asset_id = await github.rest.repos.getReleaseByTag({owner: owner, repo: repo, tag: version,}).then((response) => {
+              for (const file of response.data.assets) {
+                if (file.name == crds_tarball) {
+                  return file.id;
+                }
+              }
+              return null;
+            }, (failedResponse) => {
+              core.setFailed("Cannot obtain crds_assed_id, no matching CRDS.tar.gz found")
+            });
+            if (typeof(crds_asset_id) != "number") {
+              core.setFailed(`No ${crds_tarball} found. This is expected if the ${repo} release job is still running. Otherwise, check why the release in the controller does not contains the CRDs tarball`)
             }
+
+            console.log(`Fetching ${crds_tarball} asset with id: ${crds_asset_id}`)
+            let asset = await github.rest.repos.getReleaseAsset({
+                    owner: owner, repo: repo, asset_id: crds_asset_id, headers:{
+                            accept: "application/octet-stream"},
+            })
+            let fs = require('fs');
+            fs.writeFileSync("/tmp/crds-audit-scanner.tar.gz", Buffer.from(asset.data))
+            console.log(`${crds_tarball} downloaded successfully`)
 
       - name: Update CRDs
         if: endsWith(needs.setvariables.outputs.repository, 'kubewarden-controller') || endsWith(needs.setvariables.outputs.repository, 'audit-scanner')
@@ -243,7 +273,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Check if all components has a release with the same tag
+      - name: Check if all components have a release with the same tag
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
@@ -260,89 +290,75 @@ jobs:
               }
             }
 
-      - name: Check if CRD are available in the Kubewarden controller
+      - name: Download CRDs from Kubewarden controller
         id: download_crds_controller
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             let repository_split = process.env.repository.split("/")
             let owner = repository_split[0]
-            let repository = repository_split[1]
-            let crds_asset_id = null
-            const controller_repo = "kubewarden-controller"
+            const repo = "kubewarden-controller"
             const version = process.env.version
             const crds_tarball = "CRDS.tar.gz"
 
-            if (repository === controller_repo) {
-              crds_asset_id = process.env.crds_asset_id
-            } else {
-              crds_asset_id = await github.rest.repos.getReleaseByTag({owner: owner, repo:  controller_repo, tag: version,}).then((response) => {
-                  for (const file of response.data.assets) {
-                    if (file.name == crds_tarball) {
-                      return file.id;
-                    }
-                  }
-                  return null;
-              }, (failedResponse) => {
-                      consolog.log("FAILED")
-                      return null;
-              });
-            }
-            console.log(`Fetching asset ID: ${crds_asset_id}`)
-            if (typeof(crds_asset_id) === "number") {
-              let asset = await github.rest.repos.getReleaseAsset({
-                      owner: owner, repo: controller_repo, asset_id: crds_asset_id, headers:{
-                              accept: "application/octet-stream"},
-              })
-              let fs = require('fs');
-              fs.writeFileSync("/tmp/crds-controller.tar.gz", Buffer.from(asset.data))
-              console.log(`${crds_tarball} downloaded successfully`)
-            } else {
-              core.warning(`Aborting chart update: no ${crds_tarball} found. This is expected if the release process in the controller repository is still running. Otherwise, check why the release in the controller does not contains the CRDs tarball`)
-              core.setFailed("No CRDs tarball found")
+            console.log(`Obtaining GH asset id for ${crds_tarball} in ${process.env.repository}`)
+            let crds_asset_id = await github.rest.repos.getReleaseByTag({owner: owner, repo: repo, tag: version,}).then((response) => {
+              for (const file of response.data.assets) {
+                if (file.name == crds_tarball) {
+                  return file.id;
+                }
+              }
+              return null;
+            }, (failedResponse) => {
+              core.setFailed("Cannot obtain crds_assed_id, no matching CRDS.tar.gz found")
+            });
+            if (typeof(crds_asset_id) != "number") {
+              core.setFailed(`No ${crds_tarball} found. This is expected if the ${repo} release job is still running. Otherwise, check why the release in the controller does not contains the CRDs tarball`)
             }
 
-      - name: Check if CRD are available in the audit scanner
+            console.log(`Fetching ${crds_tarball} asset with id: ${crds_asset_id}`)
+            let asset = await github.rest.repos.getReleaseAsset({
+                    owner: owner, repo: repo, asset_id: crds_asset_id, headers:{
+                            accept: "application/octet-stream"},
+            })
+            let fs = require('fs');
+            fs.writeFileSync("/tmp/crds-controller.tar.gz", Buffer.from(asset.data))
+            console.log(`${crds_tarball} downloaded successfully`)
+
+      - name: Download CRDs from audit scanner
         id: download_crds_audit_scanner
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             let repository_split = process.env.repository.split("/")
             let owner = repository_split[0]
-            let repository = repository_split[1]
-            let crds_asset_id = null
-            const audit_scanner_repo = "audit-scanner"
+            const repo = "audit-scanner"
             const version = process.env.version
             const crds_tarball = "CRDS.tar.gz"
 
-            if (repository === audit_scanner_repo) {
-              crds_asset_id = process.env.crds_asset_id
-            } else {
-              crds_asset_id = await github.rest.repos.getReleaseByTag({owner: owner, repo:  audit_scanner_repo, tag: version,}).then((response) => {
-                  for (const file of response.data.assets) {
-                    if (file.name == crds_tarball) {
-                      return file.id;
-                    }
-                  }
-                  return null;
-              }, (failedResponse) => {
-                      consolog.log("FAILED")
-                      return null;
-              });
+            console.log(`Obtaining GH asset id for ${crds_tarball} in ${process.env.repository}`)
+            let crds_asset_id = await github.rest.repos.getReleaseByTag({owner: owner, repo: repo, tag: version,}).then((response) => {
+              for (const file of response.data.assets) {
+                if (file.name == crds_tarball) {
+                  return file.id;
+                }
+              }
+              return null;
+            }, (failedResponse) => {
+              core.setFailed("Cannot obtain crds_assed_id, no matching CRDS.tar.gz found")
+            });
+            if (typeof(crds_asset_id) != "number") {
+              core.setFailed(`No ${crds_tarball} found. This is expected if the ${repo} release job is still running. Otherwise, check why the release in the controller does not contains the CRDs tarball`)
             }
-            console.log(`Fetching asset ID: ${crds_asset_id}`)
-            if (typeof(crds_asset_id) === "number") {
-              let asset = await github.rest.repos.getReleaseAsset({
-                      owner: owner, repo: audit_scanner_repo, asset_id: crds_asset_id, headers:{
-                              accept: "application/octet-stream"},
-              })
-              let fs = require('fs');
-              fs.writeFileSync("/tmp/crds-audit-scanner.tar.gz", Buffer.from(asset.data))
-              console.log(`${crds_tarball} downloaded successfully`)
-            } else {
-              core.warning(`Aborting chart update: no ${crds_tarball} found. This is expected if the release process in the audit-scanner repository is still running. Otherwise, check why the release does not contains the CRDs tarball`)
-              core.setFailed("No CRDs tarball found")
-            }
+
+            console.log(`Fetching ${crds_tarball} asset with id: ${crds_asset_id}`)
+            let asset = await github.rest.repos.getReleaseAsset({
+                    owner: owner, repo: repo, asset_id: crds_asset_id, headers:{
+                            accept: "application/octet-stream"},
+            })
+            let fs = require('fs');
+            fs.writeFileSync("/tmp/crds-audit-scanner.tar.gz", Buffer.from(asset.data))
+            console.log(`${crds_tarball} downloaded successfully`)
 
       - name: Update CRDS
         id: update_crds

--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -53,17 +53,17 @@ jobs:
         id: from_repository_dispatch
         if: github.event_name == 'repository_dispatch'
         run: |
-          echo "old_version=${{ github.event.client_payload.oldVersion }}" >> $GITHUB_OUTPUT
-          echo "version=${{ github.event.client_payload.version }}" >> $GITHUB_OUTPUT
-          echo "repository=${{ github.event.client_payload.repository }}" >> $GITHUB_OUTPUT
+          echo "old_version=${{ github.event.client_payload.oldVersion }}" >> "$GITHUB_OUTPUT"
+          echo "version=${{ github.event.client_payload.version }}" >> "$GITHUB_OUTPUT"
+          echo "repository=${{ github.event.client_payload.repository }}" >> "$GITHUB_OUTPUT"
 
       - name: Set job output vars from workflow_dispatch input
         id: from_workflow_dispatch
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo "old_version=${{ inputs.oldVersion }}" >> $GITHUB_OUTPUT
-          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-          echo "repository=${{ inputs.repository }}" >> $GITHUB_OUTPUT
+          echo "old_version=${{ inputs.oldVersion }}" >> "$GITHUB_OUTPUT"
+          echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          echo "repository=${{ inputs.repository }}" >> "$GITHUB_OUTPUT"
 
   check-update-type:
     name: Detect update type
@@ -76,38 +76,38 @@ jobs:
     steps:
       - name: Install semver comparison tool
         run: |
-          INSTALL_DIR=$HOME/.semver
-          mkdir -p $INSTALL_DIR
-          wget -O $INSTALL_DIR/semver https://github.com/fsaintjacques/semver-tool/raw/3.4.0/src/semver
-          chmod +x $INSTALL_DIR/semver
-          echo $INSTALL_DIR >> $GITHUB_PATH
+          INSTALL_DIR="$HOME"/.semver
+          mkdir -p "$INSTALL_DIR"
+          wget -O "$INSTALL_DIR"/semver https://github.com/fsaintjacques/semver-tool/raw/3.4.0/src/semver
+          chmod +x "$INSTALL_DIR"/semver
+          echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
       - name: Check if it is a patch update
         id: check_update_type
         run: |
-          OLDVERSION=${{ needs.setvariables.outputs.old_version }}
-          NEWVERSION=${{ needs.setvariables.outputs.version }}
-          REPOSITORY=${{ needs.setvariables.outputs.repository }}
+          OLDVERSION="${{ needs.setvariables.outputs.old_version }}"
+          NEWVERSION="${{ needs.setvariables.outputs.version }}"
+          REPOSITORY="${{ needs.setvariables.outputs.repository }}"
 
-          VALID=$(semver validate $OLDVERSION)
+          VALID="$(semver validate $OLDVERSION)"
           if [[ $VALID == "invalid" ]]; then
                   exit 1
           fi
 
-          VALID=$(semver validate $NEWVERSION)
+          VALID="$(semver validate $NEWVERSION)"
           if [[ $VALID == "invalid" ]]; then
                   exit 1
           fi
-          UPDATE_TYPE=$(semver diff $OLDVERSION $NEWVERSION)
+          UPDATE_TYPE="$(semver diff $OLDVERSION $NEWVERSION)"
           PRERELEASE_SUFFIX="-$(semver get prerelease $NEWVERSION)"
           if [[ $PRERELEASE_SUFFIX == "-" ]];then
                 PRERELEASE_SUFFIX=" "
           fi
 
 
-          echo "update_type=$UPDATE_TYPE" >> $GITHUB_OUTPUT
-          echo "repository=$REPOSITORY" >> $GITHUB_OUTPUT
-          echo "prerelease=$PRERELEASE_SUFFIX" >> $GITHUB_OUTPUT
+          echo "update_type=$UPDATE_TYPE" >> "$GITHUB_OUTPUT"
+          echo "repository=$REPOSITORY" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE_SUFFIX" >> "$GITHUB_OUTPUT"
 
   patch-update:
     name: Patch release updates
@@ -124,9 +124,9 @@ jobs:
         # This is neeeded because in scripts, we don't have a way to access the `needs` json object.
         # The env vars defined here will be accesible in the scripts under `process.env.foo`
         run: |
-          echo "old_version=${{ needs.setvariables.outputs.old_version }}" >> $GITHUB_ENV
-          echo "version=${{ needs.setvariables.outputs.version }}" >> $GITHUB_ENV
-          echo "repository=${{ needs.setvariables.outputs.repository }}" >> $GITHUB_ENV
+          echo "old_version=${{ needs.setvariables.outputs.old_version }}" >> "$GITHUB_ENV"
+          echo "version=${{ needs.setvariables.outputs.version }}" >> "$GITHUB_ENV"
+          echo "repository=${{ needs.setvariables.outputs.repository }}" >> "$GITHUB_ENV"
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -251,9 +251,9 @@ jobs:
         # This is neeeded because in scripts, we don't have a way to access the `needs` json object.
         # The env vars defined here will be accesible in the scripts under `process.env.foo`
         run: |
-          echo "old_version=${{ needs.setvariables.outputs.old_version }}" >> $GITHUB_ENV
-          echo "version=${{ needs.setvariables.outputs.version }}" >> $GITHUB_ENV
-          echo "repository=${{ needs.setvariables.outputs.repository }}" >> $GITHUB_ENV
+          echo "old_version=${{ needs.setvariables.outputs.old_version }}" >> "$GITHUB_ENV"
+          echo "version=${{ needs.setvariables.outputs.version }}" >> "$GITHUB_ENV"
+          echo "repository=${{ needs.setvariables.outputs.repository }}" >> "$GITHUB_ENV"
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/updatecli/scripts/install_crds.sh
+++ b/updatecli/scripts/install_crds.sh
@@ -2,9 +2,9 @@
 
 if [ -f "/tmp/crds-controller.tar.gz" ]; then
 	tar -xf /tmp/crds-controller.tar.gz
-	find . -maxdepth 1 -name "*_policyserver*" -exec mv \{\} /tmp/helm-charts/charts/kubewarden-crds/templates/policyservers.yaml \;
-	find . -maxdepth 1 -name "*_admissionpolicies*" -exec mv \{\} /tmp/helm-charts/charts/kubewarden-crds/templates/admissionpolicies.yaml \;
-	find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec mv \{\} /tmp/helm-charts/charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
+	find . -maxdepth 1 -name "*_policyserver*" -exec mv \{\} charts/kubewarden-crds/templates/policyservers.yaml \;
+	find . -maxdepth 1 -name "*_admissionpolicies*" -exec mv \{\} charts/kubewarden-crds/templates/admissionpolicies.yaml \;
+	find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
 fi
 
 if [ -f "/tmp/crds-audit-scanner.tar.gz" ]; then


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/helm-charts/issues/307

Changes: 
- Add UI inputs when workflow triggered as `workflow_dispatch`.
  Given that the values can come from `repository_dispatch` (other repos) or `workflow_dispatch` (UI button), add a new `setvariables` job, that sets its job outputs to the corresponding values obtained from the payload of the repository_dispatch or from the inputs of the workflow_dispatch.
It is needed to use job outputs as is the only way to pass values between jobs, as jobs are run in their own VM instances and don't share the env.
  Make the following jobs depend on it with `needs: setvariables`.
  The javascript script from actions/github-script cannot read job outputs. Hence, add a step that reads the `needs.setvariables.outputs` and creates env vars. Consume those env vars in js as `process.env.foo`.
- refactor:  Calculate crds_asset_id by querying GH instead of passing it from the job.
- refactor: Remove 2 repetitions of install_crds.sh, call `update_cli/scripts/install_crds.sh`.


![image](https://github.com/kubewarden/helm-charts/assets/2196685/baedbd82-6255-48b9-841c-aa4afcb832d0)

## Test

Major/minor release update run: https://github.com/viccuad/helm-charts/actions/runs/8263364335
Patch release update run: https://github.com/viccuad/helm-charts/actions/runs/8263508789/job/22605107087

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

Also, tested `updatecli/scripts/install_crds.sh` locally, with various `/tmp/crds-{controller,audit-scanner}.tar.gz`.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

I don't like the added complexity created by adding the workflow_dispatch `inputs`, and needing to pass it to the js scripts via GH env vars, but it is what it is.

About the refactors, I'm happy splitting the commits in several PRs. I tested it altogether to save time. If they aren't wanted they can be dropped, or we can go with https://github.com/kubewarden/helm-charts/pull/399.