### PR TITLE
Add job to update policies and kubectl image

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,0 +1,24 @@
+name: Update policies and kubectl image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-dependencies:
+    name: Update policies and kubectl image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@ecfc21fd2d9e91be2af8b706ea10aea5154f6d5d # v2.54.0
+
+      - name: Update policies and images
+        id: update_policies_images
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+        run: |-
+          updatecli apply --config ./updatecli/updatecli.d/update-deps.yaml \
+                    --values updatecli/values.yaml

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -2,6 +2,8 @@ name: Update policies and kubectl image
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "30 3 * * 1" # 3:30 on Monday
 
 jobs:
   update-dependencies:

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -105,7 +105,7 @@ preDeleteJob:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/kubectl"
-    tag: "v1.27.9"
+    tag: v1.27.9
 # kubewarden-controller deployment settings:
 podAnnotations: {}
 nodeSelector: {}

--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module }}
+  module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module.repository }}:{{ .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
     - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/capabilities-policy.yaml
+++ b/charts/kubewarden-defaults/templates/capabilities-policy.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.capabilitiesPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.capabilitiesPolicy.module }}
+  module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.capabilitiesPolicy.module.repository }}:{{ .Values.recommendedPolicies.capabilitiesPolicy.module.tag }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
   - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.hostNamespacePolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: {{ template "policy_default_registry" . }}{{.Values.recommendedPolicies.hostNamespacePolicy.module}}
+  module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.hostNamespacePolicy.module.repository }}:{{ .Values.recommendedPolicies.hostNamespacePolicy.module.tag }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
   - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/host-path-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-path-policy.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.hostPathsPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: {{ template "policy_default_registry" . }}{{.Values.recommendedPolicies.hostPathsPolicy.module}}
+  module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.hostPathsPolicy.module.repository }}:{{ .Values.recommendedPolicies.hostPathsPolicy.module.tag }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
   - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
+++ b/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
@@ -12,7 +12,8 @@ metadata:
   name: {{ $.Values.recommendedPolicies.podPrivilegedPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: {{ template "policy_default_registry" . }}{{.Values.recommendedPolicies.podPrivilegedPolicy.module}}
+  module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.podPrivilegedPolicy.module.repository }}:{{ .Values.recommendedPolicies.podPrivilegedPolicy.module.tag }}
+
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
     - apiGroups: [""]

--- a/charts/kubewarden-defaults/templates/user-group-policy.yaml
+++ b/charts/kubewarden-defaults/templates/user-group-policy.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.userGroupPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
-  module: {{ template "policy_default_registry" . }}{{.Values.recommendedPolicies.userGroupPolicy.module}}
+  module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.userGroupPolicy.module.repository }}:{{ .Values.recommendedPolicies.userGroupPolicy.module.tag }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:
     - apiGroups: [""]

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -123,25 +123,37 @@ recommendedPolicies:
   skipAdditionalNamespaces: []
   defaultPolicyMode: "monitor"
   allowPrivilegeEscalationPolicy:
-    module: "kubewarden/policies/allow-privilege-escalation-psp:v0.2.6"
+    module:
+      repository: "kubewarden/policies/allow-privilege-escalation-psp"
+      tag: v0.2.6
     name: "no-privilege-escalation"
   hostNamespacePolicy:
-    module: "kubewarden/policies/host-namespaces-psp:v0.1.6"
+    module:
+      repository: "kubewarden/policies/host-namespaces-psp"
+      tag: v0.1.6
     name: "no-host-namespace-sharing"
   podPrivilegedPolicy:
-    module: "kubewarden/policies/pod-privileged:v0.3.2"
+    module:
+      repository: "kubewarden/policies/pod-privileged"
+      tag: v0.3.2
     name: "no-privileged-pod"
   userGroupPolicy:
-    module: "kubewarden/policies/user-group-psp:v0.5.0"
+    module:
+      repository: "kubewarden/policies/user-group-psp"
+      tag: v0.5.0
     name: "do-not-run-as-root"
   hostPathsPolicy:
-    module: "kubewarden/policies/hostpaths-psp:v0.1.10"
+    module:
+      repository: "kubewarden/policies/hostpaths-psp"
+      tag: v0.1.10
     name: "do-not-share-host-paths"
     paths:
       - pathPrefix: "/tmp"
         readOnly: true
   capabilitiesPolicy:
-    module: "kubewarden/policies/capabilities-psp:v0.1.15"
+    module:
+      repository: "kubewarden/policies/capabilities-psp"
+      tag: v0.1.15
     name: "drop-capabilities"
     allowed_capabilities: []
     required_drop_capabilities:

--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,14 @@
     "schedule:earlyMondays",
     "helpers:pinGitHubActionDigests"
   ],
-  "labels": ["dependencies"],
+  "labels": [
+    "area/dependencies"
+  ],
   "packageRules": [
     {
-      "matchPackagePatterns": [".*kyverno/policy-reporter-ui"],
+      "matchPackagePatterns": [
+        ".*kyverno/policy-reporter-ui"
+      ],
       "allowedVersions": "!/1.15.1$/"
     }
   ]

--- a/updatecli/DEVELOP.md
+++ b/updatecli/DEVELOP.md
@@ -1,0 +1,6 @@
+To test the updatecli manifests locally:
+
+```console
+export UPDATECLI_GITHUB_TOKEN=<your token>
+UPDATECLI_GITHUB_OWNER=<your user> updatecli diff --config updatecli/updatecli.d/update-deps.yaml --values updatecli/values.yaml
+```

--- a/updatecli/updatecli.d/major-kubewarden-update.yaml
+++ b/updatecli/updatecli.d/major-kubewarden-update.yaml
@@ -250,7 +250,6 @@ targets:
 actions:
   createUpdatePR:
     title: "Helm chart {{ requiredEnv .semverinc }} release"
-    helm-charts:
     kind: "github/pullrequest"
     scmid: "default"
     spec:

--- a/updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml
@@ -136,7 +136,6 @@ targets:
 actions:
   createUpdatePR:
     title: "Helm chart patch release"
-    helm-charts:
     kind: "github/pullrequest"
     scmid: "default"
     spec:

--- a/updatecli/updatecli.d/patch-kubewarden-controller.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-controller.yaml
@@ -61,7 +61,6 @@ targets:
 actions:
   createUpdatePR:
     title: "Helm chart patch release"
-    helm-charts:
     kind: "github/pullrequest"
     scmid: "default"
     spec:

--- a/updatecli/updatecli.d/patch-kubewarden-defaults.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-defaults.yaml
@@ -47,7 +47,6 @@ targets:
 actions:
   createUpdatePR:
     title: "Helm chart patch release"
-    helm-charts:
     kind: "github/pullrequest"
     scmid: "default"
     spec:

--- a/updatecli/updatecli.d/prerelease-kubewarden-update-with-crd-update.yaml
+++ b/updatecli/updatecli.d/prerelease-kubewarden-update-with-crd-update.yaml
@@ -262,7 +262,6 @@ targets:
 actions:
   createUpdatePR:
     title: "Helm chart {{ requiredEnv .semverinc }} release"
-    helm-charts:
     kind: "github/pullrequest"
     scmid: "default"
     spec:

--- a/updatecli/updatecli.d/prerelease-kubewarden-update.yaml
+++ b/updatecli/updatecli.d/prerelease-kubewarden-update.yaml
@@ -115,7 +115,6 @@ conditions:
         pattern: "{{ requiredEnv .releaseVersion }}"
 
 targets:
-
   updateControllerAutoInstallAnnotation:
     name: "Update kubewarden-controller auto-install annotation"
     kind: yaml
@@ -255,7 +254,6 @@ targets:
 actions:
   createUpdatePR:
     title: "Helm chart {{ requiredEnv .semverinc }} release"
-    helm-charts:
     kind: "github/pullrequest"
     scmid: "default"
     spec:

--- a/updatecli/updatecli.d/update-deps.yaml
+++ b/updatecli/updatecli.d/update-deps.yaml
@@ -118,7 +118,7 @@ actions:
       draft: false
       labels:
         - "kind/chore"
-        - "dependencies"
+        - "area/dependencies"
 
 scms:
   default:

--- a/updatecli/updatecli.d/update-deps.yaml
+++ b/updatecli/updatecli.d/update-deps.yaml
@@ -1,0 +1,138 @@
+name: Update charts with new policy versions, kubectl image
+
+sources:
+  kubectlImageTag:
+    kind: dockerimage
+    spec:
+      image: ghcr.io/kubewarden/kubectl
+      versionfilter:
+        kind: semver
+  allowPrivilegeEscalationPolicyTag:
+    kind: dockerimage
+    spec:
+      image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp
+      versionfilter:
+        kind: semver
+  hostNamespacePolicyTag:
+    kind: dockerimage
+    spec:
+      image: ghcr.io/kubewarden/policies/host-namespaces-psp
+      versionfilter:
+        kind: semver
+  podPrivilegedPolicyTag:
+    kind: dockerimage
+    spec:
+      image: ghcr.io/kubewarden/policies/pod-privileged
+      versionfilter:
+        kind: semver
+  userGroupPolicyTag:
+    kind: dockerimage
+    spec:
+      image: ghcr.io/kubewarden/policies/user-group-psp
+      versionfilter:
+        kind: semver
+  hostPathsPolicyTag:
+    kind: dockerimage
+    spec:
+      image: ghcr.io/kubewarden/policies/hostpaths-psp
+      versionfilter:
+        kind: semver
+  capabilitiesPolicyTag:
+    kind: dockerimage
+    spec:
+      image: ghcr.io/kubewarden/policies/capabilities-psp
+      versionfilter:
+        kind: semver
+
+targets:
+  updatekubectlTag:
+    name: Update kubectl image tag
+    kind: yaml
+    sourceid: kubectlImageTag
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-controller/values.yaml"
+      key: "$.preDeleteJob.image.tag"
+  updateAllowPrivilegeEscalationPolicyTag:
+    name: Update allow-privilege-escalation-psp tag
+    kind: yaml
+    sourceid: allowPrivilegeEscalationPolicyTag
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-defaults/values.yaml"
+      key: "$.recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag"
+  updateHostNamespacePolicyTag:
+    name: Update host-namespaces-psp tag
+    kind: yaml
+    sourceid: hostNamespacePolicyTag
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-defaults/values.yaml"
+      key: "$.recommendedPolicies.hostNamespacePolicy.module.tag"
+  updatePodPrivilegedPolicyTag:
+    name: Update pod-privileged tag
+    kind: yaml
+    sourceid: podPrivilegedPolicyTag
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-defaults/values.yaml"
+      key: "$.recommendedPolicies.podPrivilegedPolicy.module.tag"
+  updateUserGroupPolicyTag:
+    name: Update user-group-psp tag
+    kind: yaml
+    sourceid: userGroupPolicyTag
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-defaults/values.yaml"
+      key: "$.recommendedPolicies.userGroupPolicy.module.tag"
+  updateHostPathsPolicyTag:
+    name: Update hostpaths-psp tag
+    kind: yaml
+    sourceid: hostPathsPolicyTag
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-defaults/values.yaml"
+      key: "$.recommendedPolicies.hostPathsPolicy.module.tag"
+  updateCapabilitiesPolicyTag:
+    name: Update capabilities-psp tag
+    kind: yaml
+    sourceid: capabilitiesPolicyTag
+    scmid: "default"
+    spec:
+      file: "charts/kubewarden-defaults/values.yaml"
+      key: "$.recommendedPolicies.capabilitiesPolicy.module.tag"
+
+actions:
+  openUpdatePR:
+    title: "deps: Update policies, kubectl image"
+    kind: "github/pullrequest"
+    scmid: "default"
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic update of dependencies: policies and kubectl image
+        This PR has been created by automation.
+
+        NOTE: REMEMBER TO SQUASH MERGE
+      draft: false
+      labels:
+        - "kind/chore"
+        - "dependencies"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      directory: "/tmp/helm-charts"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "helm-charts"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ .github.branch }}"
+      commitmessage:
+        type: "deps"
+        title: "Update dependencies"
+        hidecredit: true


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/helm-charts/issues/388

Add job that checks the policies and kubectl image tags every week,
and opens a PR if there's any bump needed.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested updatecli part locally with:
```UPDATECLI_GITHUB_OWNER=viccuad updatecli diff \
  --config updatecli/updatecli.d/update-deps.yaml \
  --values updatecli/values.yaml
```

Tested `make generate-policies-file generate-images-file`, everything works for airgap scripts.

Tested in my fork:
https://github.com/viccuad/helm-charts/actions/runs/8393105846/job/22987348660
https://github.com/viccuad/helm-charts/pull/2

## Additional Information

Should wait for merge until 1.11 is released.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
