### PR TITLE
feat: Add delete-pre-1.11-policyreports-job to postinstall hook

### DIFF
--- a/charts/kubewarden-controller/templates/post-install-hook.yaml
+++ b/charts/kubewarden-controller/templates/post-install-hook.yaml
@@ -44,3 +44,53 @@ spec:
 {{ toYaml .Values.preDeleteHook.containerSecurityContext | indent 12 }}
           {{- end }}
 {{ end }}
+
+---
+# Delete pre 1.11 policy reports, as downstream consumers (Rancher UI
+# extension, Policy Reporter UI) may get confused with them.
+#
+# Pre 1.11, (Cluster)PolicyReports where created as follows:
+# - 1 ClusterPolicyReport named `polr-clusterwide`
+# - 1 PolicyReport per namespace, named `polr-ns-<namespace name>`.
+# From 1.11 onwards, (Cluster)PolicyReports are created as follows:
+# - Per each resource, create a (Cluster)PolicyReport with metadata.name that
+#   equals the resource uid.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-delete-pre-1-11-policyreports-job"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- include "kubewarden-controller.annotations" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-delete-pre-1-11-policyreports-job"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      annotations:
+        {{- include "kubewarden-controller.annotations" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ .Values.auditScanner.serviceAccountName }}
+      {{- if .Values.preDeleteHook.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.preDeleteHook.podSecurityContext | indent 8 }}
+      {{- end }}
+      containers:
+        - name: delete-pre-1-11-policyreports-job
+          image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
+          command: ["kubectl", "delete", "clusterpolicyreport,policyreport", "-l", "app.kubernetes.io/managed-by=kubewarden",  "-l", "!kubewarden.io/policyreport-version", "-A"]
+          {{- if .Values.preDeleteHook.containerSecurityContext }}
+          securityContext:
+{{ toYaml .Values.preDeleteHook.containerSecurityContext | indent 12 }}
+          {{- end }}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Part of  https://github.com/kubewarden/helm-charts/issues/408
Depends on audit-scanner 1.11.0-rc6 shipping https://github.com/kubewarden/audit-scanner/pull/231.

This job deletes all pre 1.11 (Cluster)PolicyReports, by matching and deleting those reports that lack the label
`kubewarden.io/policyreport-version`.


## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally by running the kubectl command, helm hook untested. 

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
