### PR TITLE
feat: add limits and requests to PolicyServer

### DIFF
--- a/charts/kubewarden-crds/templates/policyservers.yaml
+++ b/charts/kubewarden-crds/templates/policyservers.yaml
@@ -1142,6 +1142,16 @@ spec:
                 items:
                   type: string
                 type: array
+              limits:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Limits describes the maximum amount of compute resources
+                  allowed.
+                type: object
               maxUnavailable:
                 anyOf:
                 - type: integer
@@ -1160,6 +1170,18 @@ spec:
                 description: Replicas is the number of desired replicas.
                 format: int32
                 type: integer
+              requests:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Requests describes the minimum amount of compute resources
+                  required. If Request is omitted for, it defaults to Limits if that
+                  is explicitly specified, otherwise to an implementation-defined
+                  value
+                type: object
               securityContexts:
                 description: Security configuration to be used in the Policy Server
                   workload. The field allows different configurations for the pod

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -115,6 +115,9 @@ policyServer:
   sourceAuthorities: {}
   # affinity for pods of the default PolicyServer
   affinity: {}
+  # limits and requests, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  limits: {}
+  requests: {}
 crdVersion: "policies.kubewarden.io/v1"
 recommendedPolicies:
   enabled: False


### PR DESCRIPTION
## Description

Adds PolicyServer limits/requests values to kubewarden-default and generated CRDs with the new fields.

Related to: https://github.com/kubewarden/kubewarden-controller/issues/710

