### PR TITLE
fix: policyserver-default template

### DIFF
--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -19,8 +19,15 @@ spec:
   {{- end }}
   {{- if .Values.policyServer.maxUnavailable }}
   maxUnavailable: {{ .Values.policyServer.maxUnavailable  }}
+  {{- end }}
   {{- if .Values.policyServer.affinity }}
   affinity: {{ .Values.policyServer.affinity | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if .Values.policyServer.limits }}
+  limits: {{ .Values.policyServer.limits | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if .Values.policyServer.requests }}
+  requests: {{ .Values.policyServer.requests | toYaml | nindent 4 }}
   {{- end }}
   {{- if .Values.policyServer.verificationConfig }}
   verificationConfig: {{ .Values.policyServer.verificationConfig }}


### PR DESCRIPTION
## Description

Somehow something went wrong in the `policyserver-default` template when merging PRs, ending up with a broken template.
The CI didn't catch it so we went forward with the PR. 

Note:
We are investigating why the CI is not running the PRs helm charts, but it runs e2e tests against the already released tags.

I've re-tested the chart manually by installing it on a local cluster.