### PR TITLE
feat: expose kubewarden-controller logLevel value

### DIFF
--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
         - --enable-tracing
        {{- end }}
         - --always-accept-admission-reviews-on-deployments-namespace
+        - --zap-log-level={{ .Values.logLevel }}
         command:
         - /manager
         {{- if .Values.telemetry.metrics.enabled }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -80,6 +80,8 @@ preDeleteHook:
     allowPrivilegeEscalation: false
   podSecurityContext:
     runAsNonRoot: true
+# Verbosity of logging. Can be one of 'debug', 'info', 'error'.
+logLevel: info
 # open-telemetry options
 telemetry:
   metrics:


### PR DESCRIPTION
## Description

Exposes kubewarden-controller logLevel value, setting the `--zap-log-level` flag.

Fixes https://github.com/kubewarden/kubewarden-controller/issues/693