### PR TITLE
feat: Add annotation `artifacthub/pkg` to policies

### DIFF
--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.severity: medium
     io.kubewarden.policy.category: PSP
+    artifacthub/pkg: allow-privilege-escalation-psp/allow-privilege-escalation-psp
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/templates/capabilities-policy.yaml
+++ b/charts/kubewarden-defaults/templates/capabilities-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.category: PSP
     io.kubewarden.policy.severity: medium
+    artifacthub/pkg: capabilities-psp/capabilities-psp
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.capabilitiesPolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.category: PSP
     io.kubewarden.policy.severity: medium
+    artifacthub/pkg: host-namespaces-psp/host-namespaces-psp
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.hostNamespacePolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/templates/host-path-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-path-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.category: PSP
     io.kubewarden.policy.severity: medium
+    artifacthub/pkg: hostpaths-psp/hostpaths-psp
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.hostPathsPolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
+++ b/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.category: PSP
     io.kubewarden.policy.severity: medium
+    artifacthub/pkg: pod-privileged-policy/pod-privileged-policy
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.podPrivilegedPolicy.name }}
 spec:

--- a/charts/kubewarden-defaults/templates/user-group-policy.yaml
+++ b/charts/kubewarden-defaults/templates/user-group-policy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     io.kubewarden.policy.category: PSP
     io.kubewarden.policy.severity: medium
+    artifacthub/pkg: user-group-psp/user-group-psp
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ $.Values.recommendedPolicies.userGroupPolicy.name }}
 spec:


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
This allows the Rancher UI to find the policy package in artifacthub.io, and fetch its questions-ui from there. Hence allowing to show the policy settings when editing it.

Fixes https://github.com/rancher/kubewarden-ui/issues/669
Implementation (1) of https://github.com/rancher/kubewarden-ui/issues/669#issuecomment-2059507579

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
