### PR TITLE
feat: Expose policy settings via chart questions

### DIFF
--- a/charts/kubewarden-defaults/questions.yaml
+++ b/charts/kubewarden-defaults/questions.yaml
@@ -50,3 +50,307 @@ questions:
     description: |
       Number of replicas of the PolicyServer Deployment
     group: "Default PolicyServer HA"
+  # no-privilege-escalation policy settings
+  - variable: recommendedPolicies.allowPrivilegeEscalationPolicy.settings.default_allow_privilege_escalation
+    description: >-
+      This policy works by inspecting the containers and init containers of a Pod.
+      If any of these containers have `allowPrivilegeEscalation` enabled, the Pod
+      will be rejected.
+    tooltip: >-
+      Used to default to disallow, while still permitting pods to request
+      allowPrivilegeEscalation explicitly.
+    label: Allow privilege escalation
+    required: false
+    type: boolean
+    group: "no-privilege-escalation policy settings"
+  # drop-capabilities policy settings
+  - variable: recommendedPolicies.capabilitiesPolicy.settings.allowed_capabilities
+    description: Provides a list of capabilities that are allowed to be added to a container
+    tooltip: Specified as the capability name in ALL_CAPS. (e.g. `CHOWN`, `KILL`)
+    group: "drop-capabilities policy settings"
+    label: Allowed capabilities
+    required: false
+    type: array[
+  - variable: recommendedPolicies.capabilitiesPolicy.settings.required_drop_capabilities
+    description: The capabilities which must be dropped from containers.
+    tooltip: Specified as the capability name in ALL_CAPS. (e.g. `NET_ADMIN`)
+    group: "drop-capabilities policy settings"
+    label: Required drop capabilities
+    required: false
+    type: array[
+  - variable: recommendedPolicies.capabilitiesPolicy.settings.default_add_capabilities
+    description: >-
+      The capabilities which are added to containers by default, in addition to
+      the runtime defaults.
+    tooltip: Specified as the capability name in ALL_CAPS. (e.g. `CHOWN`)
+    group: "drop-capabilities policy settings"
+    label: Default add capabilities
+    required: false
+    type: array[
+  # no-host-namespace-sharing policy settings
+  #
+  # - default: null
+  #   description: >-
+  #     This policy works by defining what host namespaces can be used by a Pod.
+  #     `allow_host_ipc`, `allow_host_network` and `allow_host_pid` are `false` by
+  #     default. `allow_host_ports` is an empty list by default. This means that by
+  #     default host IPC, network, pid and all host ports are disabled when this
+  #     policy is loaded with no configuration.
+  #   group: no-host-namespace-sharing policy settings
+  #   label: Description
+  #   required: false
+  #   hide_input: true # TODO not implemented yet in rancher/dashboard
+  #   type: string
+  #   variable: recommendedPolicies.hostNamespacePolicy.settings.description
+  - variable: recommendedPolicies.hostNamespacePolicy.settings.allow_host_ipc
+    tooltip: Allows the pod to set .spec.HostIPC to true.
+    group: no-host-namespace-sharing policy settings
+    label: Allow host IPC
+    required: false
+    type: boolean
+  - variable: recommendedPolicies.hostNamespacePolicy.settings.allow_host_network
+    tooltip: Allows the pod to set .spec.HostNetwork to true.
+    group: no-host-namespace-sharing policy settings
+    label: Allow host network
+    required: false
+    type: boolean
+  - variable: recommendedPolicies.hostNamespacePolicy.settings.allow_host_pid
+    tooltip: Allows the pod to set .spec.HostPID to true.
+    group: no-host-namespace-sharing policy settings
+    label: Allow host PID
+    required: false
+    type: boolean
+  - variable: recommendedPolicies.hostNamespacePolicy.settings.allow_host_ports
+    description: >-
+      A range of ports to allow, an example would allow host ports `80`, `443` and
+      the range `8000-9000`.
+    group: no-host-namespace-sharing policy settings
+    label: Allow host ports
+    hide_input: true
+    type: sequence[
+    sequence_questions:
+      - default: 0
+        tooltip: ""
+        group: no-host-namespace-sharing policy settings
+        label: min
+        type: int
+        variable: min
+      - default: 0
+        tooltip: ""
+        group: no-host-namespace-sharing policy settings
+        label: max
+        type: int
+        variable: max
+  # no-privileged-pod policy settings
+  - variable: recommendedPolicies.podPrivilegedPolicy.settings.skip_init_containers
+    tooltip: >-
+      Ignore that some init container is configured as privileged
+    group: no-privileged-pod policy settings
+    label: Skip init containers
+    required: false
+    type: boolean
+  - variable: recommendedPolicies.podPrivilegedPolicy.settings.skip_ephemeral_containers
+    tooltip: >-
+      Ignore that some ephemeral container is configured as privileged
+    group: no-privileged-pod policy settings
+    label: Skip ephemeral containers
+    required: false
+    type: boolean
+  # do-not-run-as-root policy
+  #
+  # TODO sequence[ is not implemented in rancher/dashboard yet: https://github.com/rancher/dashboard/issues/10826
+  #
+  # - default: null
+  #   description: >-
+  #     This policy is a replacement for the Kubernetes Pod Security Policy that
+  #     controls containers user and groups.
+  #   group: do-not-run-as-root policy settings
+  #   label: Description
+  #   required: false
+  #   hide_input: true # TODO not implemented yet in rancher/dashboard
+  #   type: string
+  #   variable: recommendedPolicies.userGroupPolicy.settings.description
+  # - variable: recommendedPolicies.userGroupPolicy.settings.run_as_user
+  #   description: Controls which user ID the containers are run with.
+  #   group: do-not-run-as-root policy settings
+  #   label: Run as user
+  #   hide_input: true
+  #   type: map[
+  #   subquestions:
+  #     - variable: recommendedPolicies.userGroupPolicy.settings.run_as_user.rule
+  #       tooltip: >-
+  #         Defines the strategy used by the policy to enforce users and groups used
+  #         in containers.
+  #       group: do-not-run-as-root policy settings
+  #       label: Rule
+  #       options:
+  #         - MustRunAs
+  #         - MustRunAsNonRoot
+  #         - RunAsAny
+  #       type: enum
+  #     - variable: recommendedPolicies.userGroupPolicy.settings.run_as_user.overwrite
+  #       group: do-not-run-as-root policy settings
+  #       label: Overwrite
+  #       show_if: recommendedPolicies.userGroupPolicy.settings.run_as_user.rule=MustRunAs
+  #       title: Overwrite
+  #       tooltip: >-
+  #         The overwrite attribute can be set only with the MustRunAs rule. This
+  #         flag configures the policy to mutate the runAsUser or runAsGroup despite
+  #         of the value present in the request - even if the value is a valid one.
+  #         The default value of this attribute is false.
+  #       type: boolean
+  #     - variable: recommendedPolicies.userGroupPolicy.settings.run_as_user.ranges
+  #       description: >-
+  #         Ranges is a list of JSON objects with two attributes: min and max. Each
+  #         range object define the user/group ID range used by the rule.
+  #       group: do-not-run-as-root policy settings
+  #       label: Ranges
+  #       show_if: recommendedPolicies.userGroupPolicy.settings.run_as_user.rule=MustRunAs||recommendedPolicies.userGroupPolicy.settings.run_as_user.rule=MustRunAsNonRoot
+  #       hide_input: true
+  #       type: sequence[
+  #       sequence_questions:
+  #         - default: 0
+  #           group: do-not-run-as-root policy settings
+  #           label: min
+  #           show_if: recommendedPolicies.userGroupPolicy.settings.run_as_user.rule=MustRunAs||recommendedPolicies.userGroupPolicy.settings.run_as_user.rule=MustRunAsNonRoot
+  #           tooltip: Minimum UID or GID
+  #           type: int
+  #           variable: min
+  #         - default: 0
+  #           group: do-not-run-as-root policy settings
+  #           label: max
+  #           show_if: recommendedPolicies.userGroupPolicy.settings.run_as_user.rule=MustRunAs||recommendedPolicies.userGroupPolicy.settings.run_as_user.rule=MustRunAsNonRoot
+  #           tooltip: Maxium UID or GID
+  #           type: int
+  #           variable: max
+  # - variable: recommendedPolicies.userGroupPolicy.settings.run_as_group
+  #   description: Controls which primary group ID the containers are run with.
+  #   group: do-not-run-as-root policy settings
+  #   label: Run as group
+  #   hide_input: true
+  #   type: map[
+  #   subquestions:
+  #     - variable: recommendedPolicies.userGroupPolicy.settings.run_as_group.rule
+  #       tooltip: >-
+  #         Defines the strategy used by the policy to enforce users and groups used
+  #         in containers.
+  #       group: do-not-run-as-root policy settings
+  #       label: Rule
+  #       options:
+  #         - MustRunAs
+  #         - MayRunAs
+  #         - RunAsAny
+  #       type: enum
+  #     - variable: recommendedPolicies.userGroupPolicy.settings.run_as_group.overwrite
+  #       group: do-not-run-as-root policy settings
+  #       label: Overwrite
+  #       show_if: recommendedPolicies.userGroupPolicy.settings.run_as_group.rule=MustRunAs
+  #       type: boolean
+  #     - variable: recommendedPolicies.userGroupPolicy.settings.run_as_group.ranges
+  #       description: >-
+  #         Ranges is a list of JSON objects with two attributes: min and max. Each
+  #         range object define the user/group ID range used by the rule.
+  #       group: do-not-run-as-root policy settings
+  #       label: Ranges
+  #       show_if: recommendedPolicies.userGroupPolicy.settings.run_as_group.rule=MustRunAs||recommendedPolicies.userGroupPolicy.settings.run_as_group.rule=MayRunAs
+  #       hide_input: true
+  #       type: sequence[
+  #       sequence_questions:
+  #         - default: 0
+  #           group: do-not-run-as-root policy settings
+  #           label: min
+  #           show_if: recommendedPolicies.userGroupPolicy.settings.run_as_group.rule=MustRunAs||recommendedPolicies.userGroupPolicy.settings.run_as_group.rule=MayRunAs
+  #           tooltip: Minimum UID or GID
+  #           type: int
+  #           variable: min
+  #         - default: 0
+  #           group: do-not-run-as-root policy settings
+  #           label: max
+  #           show_if: recommendedPolicies.userGroupPolicy.settings.run_as_group.rule=MustRunAs||recommendedPolicies.userGroupPolicy.settings.run_as_group.rule=MayRunAs
+  #           tooltip: Maxium UID or GID
+  #           type: int
+  #           variable: max
+  # - variable: recommendedPolicies.userGroupPolicy.settings.supplemental_groups
+  #   description: Controls which group IDs containers add.
+  #   group: do-not-run-as-root policy settings
+  #   label: Supplemental groups
+  #   hide_input: true
+  #   type: map[
+  #   subquestions:
+  #     - variable: recommendedPolicies.userGroupPolicy.settings.supplemental_groups.rule
+  #       tooltip: >-
+  #         Defines the strategy used by the policy to enforce users and groups used
+  #         in containers.
+  #       group: do-not-run-as-root policy settings
+  #       label: Rule
+  #       options:
+  #         - MustRunAs
+  #         - MayRunAs
+  #         - RunAsAny
+  #       type: enum
+  #     - variable: recommendedPolicies.userGroupPolicy.settings.supplemental_groups.overwrite
+  #       group: do-not-run-as-root policy settings
+  #       label: Overwrite
+  #       show_if: >-
+  #         recommendedPolicies.userGroupPolicy.settings.supplemental_groups.rule=MustRunAs
+  #       type: boolean
+  #     - variable: recommendedPolicies.userGroupPolicy.settings.supplemental_groups.ranges
+  #       description: >-
+  #         Ranges is a list of JSON objects with two attributes: min and max. Each
+  #         range object define the user/group ID range used by the rule.
+  #       group: do-not-run-as-root policy settings
+  #       label: Ranges
+  #       show_if: >-
+  #         recommendedPolicies.userGroupPolicy.settings.supplemental_groups.rule=MustRunAs||recommendedPolicies.userGroupPolicy.settings.supplemental_groups.rule=MayRunAs
+  #       hide_input: true
+  #       type: sequence[
+  #       sequence_questions:
+  #         - default: 0
+  #           group: do-not-run-as-root policy settings
+  #           label: min
+  #           show_if: >-
+  #             recommendedPolicies.userGroupPolicy.settings.supplemental_groups.rule=MustRunAs||recommendedPolicies.userGroupPolicy.settings.supplemental_groups.rule=MayRunAs
+  #           tooltip: Minimum UID or GID
+  #           type: int
+  #           variable: min
+  #         - default: 0
+  #           group: do-not-run-as-root policy settings
+  #           label: max
+  #           show_if: >-
+  #             recommendedPolicies.userGroupPolicy.settings.supplemental_groups.rule=MustRunAs||recommendedPolicies.userGroupPolicy.settings.supplemental_groups.rule=MayRunAs
+  #           tooltip: Maxium UID or GID
+  #           type: int
+  #           variable: max
+  # do-not-share-host-paths policy settings
+  #
+  # TODO sequence[ is not implemented in rancher/dashboard yet: https://github.com/rancher/dashboard/issues/10826
+  #
+  # - variable: recommendedPolicies.hostPathsPolicy.settings.allowedHostPaths
+  #   description: >-
+  #     This policy is a replacement for the Kubernetes Pod Security Policy that
+  #     controls the usage of `hostPath` volumes. The policy inspects both the
+  #     containers and the init containers that are using `hostPath` volumes.
+  #     `allowedHostPaths` is a list of host paths that are allowed to be used by
+  #     hostPath volumes. An empty `allowedHostPaths` list means there is no
+  #     restriction on host paths used. Each entry of `allowedHostPaths` must have:
+  #     a `pathPrefix` field, which allows hostPath volumes to mount a path that
+  #     begins with an allowed prefix, and a `readOnly` field indicating it must be
+  #     mounted read-only.
+  #   tooltip: A list of host paths that are allowed to be used by hostPath volumes.
+  #   group: do-not-share-host-paths policy settings
+  #   label: Allow host path
+  #   hide_input: true
+  #   type: sequence[
+  #   sequence_questions:
+  #     - variable: pathPrefix
+  #       description: >-
+  #         Allows hostPath volumes to mount a path that begins with an allowed
+  #         prefix.
+  #       group: do-not-share-host-paths policy settings
+  #       label: Path prefix
+  #       type: string
+  #     - variable: readOnly
+  #       tooltip: Indicates if the volume must be mounted read-only.
+  #       group: do-not-share-host-paths policy settings
+  #       label: Read only
+  #       type: boolean

--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -21,5 +21,5 @@ spec:
       operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
   mutating: true
   settings:
-    default_allow_privilege_escalation: false
+    {{- toYaml .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.settings | replace "|\n" "" | nindent 2 }}
 {{ end }}

--- a/charts/kubewarden-defaults/templates/capabilities-policy.yaml
+++ b/charts/kubewarden-defaults/templates/capabilities-policy.yaml
@@ -23,22 +23,5 @@ spec:
     - UPDATE
   mutating: true
   settings:
-{{- if .Values.recommendedPolicies.capabilitiesPolicy.allowed_capabilities }}
-      allowed_capabilities:
-      {{- range .Values.recommendedPolicies.capabilitiesPolicy.allowed_capabilities }}
-        - {{ . }}
-      {{- end }}
-{{- end }}
-{{- if .Values.recommendedPolicies.capabilitiesPolicy.required_drop_capabilities }}
-      required_drop_capabilities:
-      {{- range .Values.recommendedPolicies.capabilitiesPolicy.required_drop_capabilities }}
-        - {{ . }}
-      {{- end }}
-{{- end }}
-{{- if .Values.recommendedPolicies.capabilitiesPolicy.default_add_capabilities }}
-      default_add_capabilities:
-      {{- range .Values.recommendedPolicies.capabilitiesPolicy.default_add_capabilities }}
-        - {{ . }}
-      {{- end }}
-{{- end }}
+    {{- toYaml .Values.recommendedPolicies.capabilitiesPolicy.settings | replace "|\n" "" | nindent 2 }}
 {{ end }}

--- a/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
@@ -23,7 +23,5 @@ spec:
     - UPDATE
   mutating: false
   settings:
-    allow_host_ipc: false
-    allow_host_network: false
-    allow_host_pid: false
+    {{- toYaml .Values.recommendedPolicies.hostNamespacePolicy.settings | replace "|\n" "" | nindent 2 }}
 {{ end }}

--- a/charts/kubewarden-defaults/templates/host-path-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-path-policy.yaml
@@ -23,9 +23,5 @@ spec:
     - UPDATE
   mutating: false
   settings:
-    allowedHostPaths:
-{{- range .Values.recommendedPolicies.hostPathsPolicy.paths }}
-    - pathPrefix:  {{ .pathPrefix | quote }}
-      readOnly: {{ .readOnly  }}
-{{- end }}
+    {{- toYaml .Values.recommendedPolicies.hostPathsPolicy.settings | replace "|\n" "" | nindent 2 }}
 {{ end }}

--- a/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
+++ b/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
@@ -34,6 +34,5 @@ spec:
       operations: ["CREATE", "UPDATE"]
   mutating: false
   settings:
-    skip_init_containers: false
-    skip_ephemeral_containers: false
+    {{- toYaml .Values.recommendedPolicies.podPrivilegedPolicy.settings | replace "|\n" "" | nindent 2 }}
 {{ end }}

--- a/charts/kubewarden-defaults/templates/user-group-policy.yaml
+++ b/charts/kubewarden-defaults/templates/user-group-policy.yaml
@@ -21,10 +21,5 @@ spec:
       operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
   mutating: true
   settings:
-    run_as_user:
-      rule: "MustRunAsNonRoot"
-    run_as_group:
-      rule: "RunAsAny"
-    supplemental_groups:
-      rule: "RunAsAny"
+    {{- toYaml .Values.recommendedPolicies.userGroupPolicy.settings | replace "|\n" "" | nindent 2 }}
 {{ end }}

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -134,35 +134,54 @@ recommendedPolicies:
       repository: "kubewarden/policies/allow-privilege-escalation-psp"
       tag: v0.2.6
     name: "no-privilege-escalation"
+    settings:
+      default_allow_privilege_escalation: false
   hostNamespacePolicy:
     module:
       repository: "kubewarden/policies/host-namespaces-psp"
       tag: v0.1.6
     name: "no-host-namespace-sharing"
+    settings:
+      allow_host_ipc: false
+      allow_host_network: false
+      allow_host_pid: false
+      allow_host_ports: []
   podPrivilegedPolicy:
     module:
       repository: "kubewarden/policies/pod-privileged"
       tag: v0.3.2
     name: "no-privileged-pod"
+    settings:
+      skip_init_containers: false
+      skip_ephemeral_containers: false
   userGroupPolicy:
     module:
       repository: "kubewarden/policies/user-group-psp"
       tag: v0.5.0
     name: "do-not-run-as-root"
+    settings:
+      run_as_user:
+        rule: "MustRunAsNonRoot"
+      run_as_group:
+        rule: "RunAsAny"
+      supplemental_groups:
+        rule: "RunAsAny"
   hostPathsPolicy:
     module:
       repository: "kubewarden/policies/hostpaths-psp"
       tag: v0.1.10
     name: "do-not-share-host-paths"
-    paths:
-      - pathPrefix: "/tmp"
-        readOnly: true
+    settings:
+      allowedHostPaths:
+        - pathPrefix: "/tmp"
+          readOnly: true
   capabilitiesPolicy:
     module:
       repository: "kubewarden/policies/capabilities-psp"
       tag: v0.1.15
     name: "drop-capabilities"
-    allowed_capabilities: []
-    required_drop_capabilities:
-      - ALL
-    default_add_capabilities: []
+    settings:
+      allowed_capabilities: []
+      required_drop_capabilities:
+        - ALL
+      default_add_capabilities: []


### PR DESCRIPTION
## Description

Add default policies questions.yaml into the chart questions, so if they are configured via chart, one sees their settings questions.

This is an alternative to https://github.com/kubewarden/helm-charts/pull/426.

This is possible for all policies besides those using `type: sequence[`, as that isn't ported to rancher/dashboard yet. Opened https://github.com/rancher/dashboard/issues/10826, https://github.com/rancher/dashboard/issues/10827 for that. For those, I have left the questions commented and they aren't customizable, as `type: yaml` is buggy for now (see https://github.com/rancher/dashboard/issues/10814).

Fixes https://github.com/kubewarden/helm-charts/pull/426

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->


## Test
![image](https://github.com/kubewarden/helm-charts/assets/2196685/f25a0034-ca6c-4618-a7a4-cc32d8699a78)


Tested by installing a repo consuming this pr.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement



If this is merged, the UI could redirect to the kubewarden-defaults chart update page instead of allowing updating the policies by themselves (which is bound to be overwritten by the chart at some point, and for which the questions may be out of sync with the policy).