### PR TITLE
build: Bump kubewarden-defaults version to 2.0.0-rc4

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.5-rc3
+version: 2.0.0-rc4
 # This is the version of Kubewarden stack
 appVersion: v1.12.0-rc2
 annotations:


### PR DESCRIPTION
## Description

Bump kubewarden-defaults version to **2.0.0-rc4** because of the following breaking changes:
Changes to values.yaml under `recommendedPolicies`. All policies now have `recommendedPolicies.Foo.settings` for our preferred settings, instead of having them set in the templates.



<!-- Please provide the link to the GitHub issue you are addressing -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
