### PR TITLE
fix: update description of PolicyServer ServiceAccount

### DIFF
--- a/charts/kubewarden-defaults/questions.yaml
+++ b/charts/kubewarden-defaults/questions.yaml
@@ -38,8 +38,8 @@ questions:
     required: true
     label: Name of the ServiceAccount associated to the PolicyServer default
     description: |
-      Minimum number of policy-server Pods that must be available at all times.
-      Can be an integer or a percentage.
+      The ServiceAccount that is being used by the default PolicyServer to interact
+      with the Kubernetes API Server.
     group: "Default PolicyServer"
   # Default PolicyServer HA
   - variable: "policyServer.replicaCount"


### PR DESCRIPTION
Inside of the questions of the `kubewarden-defaults` helm chart, use a proper description for the ServiceAccount value.

Prior to this commit, a copy-and-pasted value was being used.

Fixes https://github.com/kubewarden/helm-charts/issues/437
