### PR TITLE
fix: Don't expose hostNamespacePolicy.settings.allow_host_ports in questions

### DIFF
--- a/charts/kubewarden-defaults/questions.yaml
+++ b/charts/kubewarden-defaults/questions.yaml
@@ -120,27 +120,30 @@ questions:
     label: Allow host PID
     required: false
     type: boolean
-  - variable: recommendedPolicies.hostNamespacePolicy.settings.allow_host_ports
-    description: >-
-      A range of ports to allow, an example would allow host ports `80`, `443` and
-      the range `8000-9000`.
-    group: no-host-namespace-sharing policy settings
-    label: Allow host ports
-    hide_input: true
-    type: sequence[
-    sequence_questions:
-      - default: 0
-        tooltip: ""
-        group: no-host-namespace-sharing policy settings
-        label: min
-        type: int
-        variable: min
-      - default: 0
-        tooltip: ""
-        group: no-host-namespace-sharing policy settings
-        label: max
-        type: int
-        variable: max
+  #
+  # TODO sequence[ is not implemented in rancher/dashboard yet: https://github.com/rancher/dashboard/issues/10826
+  #
+  # - variable: recommendedPolicies.hostNamespacePolicy.settings.allow_host_ports
+  #   description: >-
+  #     A range of ports to allow, an example would allow host ports `80`, `443` and
+  #     the range `8000-9000`.
+  #   group: no-host-namespace-sharing policy settings
+  #   label: Allow host ports
+  #   hide_input: true
+  #   type: sequence[
+  #   sequence_questions:
+  #     - default: 0
+  #       tooltip: ""
+  #       group: no-host-namespace-sharing policy settings
+  #       label: min
+  #       type: int
+  #       variable: min
+  #     - default: 0
+  #       tooltip: ""
+  #       group: no-host-namespace-sharing policy settings
+  #       label: max
+  #       type: int
+  #       variable: max
   # no-privileged-pod policy settings
   - variable: recommendedPolicies.podPrivilegedPolicy.settings.skip_init_containers
     tooltip: >-


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/helm-charts/issues/439.

hostNamespacePolicy.settings.allow_host_ports depends on `sequence_questions`, unimplemented yet in rancher/dashboard.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
