### PR TITLE
fix: audit scanner delete collection permission.

### DIFF
--- a/charts/kubewarden-controller/templates/rbac.yaml
+++ b/charts/kubewarden-controller/templates/rbac.yaml
@@ -246,7 +246,7 @@ rules:
     - clusterpolicyreports
   verbs:
     - create
-    - delete
+    - deletecollection
     - get
     - list
     - patch


### PR DESCRIPTION
## Description

To clean up old policy reports created by audit scanner, it needs permissions to delete a collection of the reports. Requiring a change in the scanner role adding the "deletecollection" verb.

Fix https://github.com/kubewarden/audit-scanner/issues/263
