### PR TITLE
feat: expose new audit-scanner flags

### DIFF
--- a/charts/kubewarden-controller/questions.yaml
+++ b/charts/kubewarden-controller/questions.yaml
@@ -57,6 +57,54 @@ questions:
     description: |
       Additional namespaces that the audit scanner will not scan.
     group: "Audit checks"
+  - variable: "auditScanner.parallelNamespaces"
+    type: integer
+    default: 1
+    required: false
+    show_if: auditScanner.enable=true
+    label: Number of Namespaces to be audited in parallel
+    description: |
+      The audit-scanner iterate over all the Namespaces in the cluster. This
+      value controls how many Namespaces are audited at the same time.
+    group: "Audit checks"
+  - variable: "auditScanner.parallelResources"
+    type: integer
+    default: 100
+    required: false
+    show_if: auditScanner.enable=true
+    label: Number of resources to be audited in parallel
+    description: |
+      The audit-scanner iterates over all the resources of a certain type found
+      inside of a Namespace. This parameter controls how many resources are
+      audited at the same time.
+
+      For example, if a Namespace has 1000 Pods, and this value is set to 100,
+      the audit-scanner will audit 100 Pods at the same time.
+    group: "Audit checks"
+  - variable: "auditScanner.parallelPolicies"
+    type: integer
+    default: 5
+    required: false
+    show_if: auditScanner.enable=true
+    label: Number of policies to evaluate fora given resournce in parallel
+    description: |
+      For each specific resource, the audit-scanner evaluates all the policies
+      that are interested about this kind of resource. This parameter controls
+      how many policies are evaluated at the same time.
+
+      For example, if 10 policies are interested in Pods, and this value is set
+      to 5, the audit-scanner will evaluate 5 policies at the same time.
+    group: "Audit checks"
+  - variable: "auditScanner.pageSize"
+    type: integer
+    default: 100
+    required: false
+    show_if: auditScanner.enable=true
+    label: Number of resources to fetch from the Kubernetes API server when paginating
+    description: |
+      When looking into a specific type of resource, audit-scanner fetches these objects
+      in chunks. This parameter controls how many resources are fetched at the same time.
+    group: "Audit checks"
   # controller HA:
   - variable: "replicas"
     type: integer

--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -113,11 +113,31 @@ Create the name of the service account to use for kubewarden-controller
 {{- end -}}
 
 {{- define "audit-scanner.command" -}}
+{{- $parallelNamespaces := .Values.auditScanner.parallelNamespaces | int -}}
+{{- $parallelResources := .Values.auditScanner.parallelResources | int -}}
+{{- $parallelPolicies := .Values.auditScanner.parallelPolicies | int -}}
+{{- $pageSize := .Values.auditScanner.pageSize| int -}}
 - /audit-scanner
 - --kubewarden-namespace
 - {{ .Release.Namespace }}
 - --loglevel
 - {{ .Values.auditScanner.logLevel }}
+{{- if gt $parallelNamespaces 0 }}
+- --parallel-namespaces
+- {{ $parallelNamespaces }}
+{{- end }}
+{{- if gt $parallelResources 0 }}
+- --parallel-resources
+- {{ $parallelResources }}
+{{- end }}
+{{- if gt $parallelPolicies 0 }}
+- --parallel-policies
+- {{ $parallelPolicies }}
+{{- end }}
+{{- if gt $pageSize 0 }}
+- --page-size
+- {{ $pageSize }}
+{{- end }}
 {{- if .Values.auditScanner.disableStore }}
 - --disable-store
 {{- end }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -171,6 +171,14 @@ auditScanner:
   outputScan: false
   # Configures whether a (Cluster)PolicyReport is stored in Kubernetes/etcd or not
   disableStore: false
+  # Configures the number of Namespaces to be audited in parallel
+  parallelNamespaces: 1
+  # Configures the number of resources to be audited in parallel
+  parallelResources: 100
+  # Configures the number of policies to evaluate for a given resource in parallel
+  parallelPolicies: 5
+  # Configures the number of resources to fetch from the Kubernetes API server when paginating
+  pageSize: 100
 # Values to configure the policy reporter subchart enabled by the
 # auditScanner.policyReporter flag
 policy-reporter:


### PR DESCRIPTION
Update the helm kubewarden-controller to expose the new flags of the audit-scanner
