### PR TITLE
fix release numbers

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0-rc2
+version: 2.1.0-rc1
 # This is the version of Kubewarden stack
 appVersion: v1.13.0-rc2
 annotations:
@@ -35,14 +35,14 @@ annotations:
   catalog.cattle.io/display-name: Kubewarden # Only for Charts with custom UI
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
-  catalog.cattle.io/auto-install: kubewarden-crds=1.6.0-rc2
+  catalog.cattle.io/auto-install: kubewarden-crds=1.5.1-rc2
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
   # The following two will create a UI warning if the request is not available in cluster
   # Assume the most standard setup for your chart. These can be strings with amounts, ie 64Mi or 2Gi are both valid.
   catalog.cattle.io/requests-cpu: "250m"
   catalog.cattle.io/requests-memory: "50Mi"
   catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.9.100-0" # Chart will only be available for users in the specified Rancher version(s), here its 2.5.0-2.5.99. This _must_ use build metadata or it won't work correctly for future RC's.
-  catalog.cattle.io/upstream-version: 2.1.0-rc2
+  catalog.cattle.io/upstream-version: 2.1.0-rc1
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0-rc2
+version: 1.5.1-rc2
 # This is the version of Kubewarden stack
 appVersion: v1.13.0-rc2
 annotations:
@@ -33,7 +33,7 @@ annotations:
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
   catalog.cattle.io/hidden: "true" # Hide specific charts. Only use on CRD charts.
-  catalog.cattle.io/upstream-version: 1.6.0-rc2
+  catalog.cattle.io/upstream-version: 1.5.1-rc2
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0-rc2
+version: 2.0.1-rc2
 # This is the version of Kubewarden stack
 appVersion: v1.13.0-rc2
 annotations:
@@ -35,8 +35,8 @@ annotations:
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
   catalog.cattle.io/hidden: "true" # Hide specific charts. Only use on CRD charts.
-  catalog.cattle.io/upstream-version: 2.1.0-rc2
-  catalog.cattle.io/auto-install: kubewarden-crds=1.6.0-rc2
+  catalog.cattle.io/upstream-version: 2.0.1-rc2
+  catalog.cattle.io/auto-install: kubewarden-crds=1.5.1-rc2
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool


### PR DESCRIPTION
Automation overwrote the changes we did to https://github.com/kubewarden/helm-charts/pull/454

This brings back the right values.

Note well: I've deleted all the tags and the GitHub release objects created by the automation.
