### PR TITLE
fix: use domain qualified finalizers in the default policy server.

### DIFF
--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
   name: {{ .Values.global.policyServer.default.name }}
   finalizers:
-    - kubewarden
+    - kubewarden.io/finalizer
 spec:
   image: {{ template "system_default_registry" . }}{{ .Values.policyServer.image.repository }}:{{ .Values.policyServer.image.tag }}
   serviceAccountName: {{ .Values.policyServer.serviceAccountName }}


### PR DESCRIPTION
## Description

Updates the default policy server to use domain qualified finalizer and follow the change in the controller as well.

Related to https://github.com/kubewarden/kubewarden-controller/issues/728

## Test

Manual testing
