### PR TITLE
fix!: remove the default policy server name.

### DIFF
--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -45,9 +45,6 @@ spec:
         args:
         - --leader-elect
         - --deployments-namespace={{ .Release.Namespace }}
-        {{- if .Values.global.policyServer.default.enabled }}
-        - --default-policy-server={{ .Values.global.policyServer.default.name }}
-        {{- end }}
        {{- if .Values.telemetry.metrics.enabled }}
         - --enable-metrics
        {{- end }}

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -99,10 +99,7 @@ global:
     - rancher-alerting-drivers
     - security-scan
     - tigera-operator
-  policyServer:
-    default:
-      name: default
-      enabled: true
+
 # Settings for kubewarden-controller.
 # nameOverride Replaces the release name of the chart in Chart.yaml file when
 # this is used to construct Kubernetes object names

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.policyServer.default.enabled }}
+{{- if .Values.policyServer.enabled }}
 apiVersion: {{ $.Values.crdVersion }}
 kind: PolicyServer
 metadata:
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: policy-server
   annotations:
     {{- include "kubewarden-defaults.annotations" . | nindent 4 }}
-  name: {{ .Values.global.policyServer.default.name }}
+  name: default
   finalizers:
     - kubewarden.io/finalizer
 spec:

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -99,10 +99,7 @@ global:
     - rancher-alerting-drivers
     - security-scan
     - tigera-operator
-  policyServer:
-    default:
-      name: default
-      enabled: true
+
 # -- Additional labels to add to all resources
 additionalLabels: {}
 # app: kubewarden-defaults
@@ -111,6 +108,7 @@ additionalAnnotations: {}
 # owner: IT-group1
 # Policy Server settings
 policyServer:
+  enabled: true
   replicaCount: 1
   minAvailable: ""
   maxUnavailable: ""

--- a/common-values.yaml
+++ b/common-values.yaml
@@ -45,9 +45,5 @@ global:
     - rancher-alerting-drivers
     - security-scan
     - tigera-operator
-  policyServer:
-    default:
-      name: default
-      enabled: true
   affinity: {}
   tolerations: []


### PR DESCRIPTION
## Description

The Kubewarden controller does not have the CLI flag to allow users to define the name of the default policy server name. Therefore, the helm chart does not need that configuration anymore. Thus, this commit removes the global values to configure that in the kubewarden-controller and kubewarden-default charts.


Fix  https://github.com/kubewarden/kubewarden-controller/issues/809
