### PR TITLE
Revert "deps: Bump OpenTelemetryCollector to v1beta1 (#479)"

### DIFF
--- a/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
+++ b/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
@@ -1,5 +1,5 @@
 {{ if or .Values.telemetry.metrics.enabled .Values.telemetry.tracing.enabled }}
-apiVersion: opentelemetry.io/v1beta1
+apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
   name: kubewarden


### PR DESCRIPTION
This reverts commit 05a6207ae18d7fce5fc96c93491e119b9254bd48.

This revert ought to fix the jaeger helm chart install error:
```
jaeger.jaegertracing.io/my-open-telemetry created
   Error: UPGRADE FAILED: failed to create resource: admission webhook "mopentelemetrycollectorbeta.kb.io" denied the request: json: cannot unmarshal string into Go struct field OpenTelemetryCollectorSpec.spec.config of type v1beta1.Config
```

There seems to be incompatibilities between latest jaeger-operator-2.54.0 (from 2024-06) and latest opentelemetry-operator-0.64.4.

The latest opentelemetry-operator chart includes the operator image 0.103.0 but has not yet consumed 0.104.0, which performs the migrationg to OpentelemetryCollector apiVersion `opentelemetry.io/v1beta1`.

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #XXX

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
