### PR TITLE
chore: Correctly terminate null objects in collector template

### DIFF
--- a/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
+++ b/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
@@ -14,9 +14,9 @@ spec:
     receivers:
       otlp:
         protocols:
-          grpc:
+          grpc: {}
     processors:
-      batch:
+      batch: {}
     exporters:
       {{- if and .Values.telemetry.tracing.enabled .Values.telemetry.tracing.jaeger.endpoint }}
       otlp/jaeger:


### PR DESCRIPTION
## Description


This removes warning:
```
W0725 16:45:37.530588   37879 warnings.go:70] Collector config
spec.config has null objects: processors.batch:,
receivers.otlp.protocols.grpc:. For compatibility with other tooling,
such as kustomize and kubectl edit, it is recommended to use empty
objects e.g. batch: {}.
```


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested manually.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
