### PR TITLE
fix: Use correct default settings for userGroup policy

### DIFF
--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -216,7 +216,7 @@ recommendedPolicies:
         rule: "RunAsAny"
       supplemental_groups:
         rule: "RunAsAny"
-      "validate_container_image_configuration": true
+      validate_container_image_configuration: false
   hostPathsPolicy:
     module:
       repository: "kubewarden/policies/hostpaths-psp"


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
The userGroup policy shouldn't validate the container image configuration to check for the user being run there, as that is too stringent.

Coincidentally, this ameliorates https://github.com/kubewarden/user-group-psp-policy/issues/93
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
