### PR TITLE
fix: values.schema.json PDB variable type

### DIFF
--- a/charts/kubewarden-defaults/values.schema.json
+++ b/charts/kubewarden-defaults/values.schema.json
@@ -6,10 +6,10 @@
       "type": "object",
       "properties": {
         "maxUnavailable": {
-          "type": "string"
+          "type": "integer"
         },
         "minAvailable": {
-          "type": "string"
+          "type": "integer"
         }
       },
       "allOf": [
@@ -17,11 +17,11 @@
           "not": {
             "properties": {
               "minAvailable": {
-                "type": "string",
+                "type": "integer",
                 "minLength": 1
               },
               "maxUnavailable": {
-                "type": "string",
+                "type": "integer",
                 "minLength": 1
               }
             }


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Breaking some automations while passing parameters from one file another. Original variable type should be corrected. Otherwise facing unnecessary issues. 

 Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
kubewarden-defaults: policyServer.minAvailable: Invalid type. Expected: string, given: integer

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
