### PR TITLE
fix: schema with XOR for minAvailable, maxUnavailable

### DIFF
--- a/charts/kubewarden-defaults/values.schema.json
+++ b/charts/kubewarden-defaults/values.schema.json
@@ -1,30 +1,40 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {
     "policyServer": {
       "type": "object",
       "properties": {
         "maxUnavailable": {
-          "type": "integer"
+          "type": "string",
+          "minLength": 1
         },
         "minAvailable": {
-          "type": "integer"
+          "type": "string",
+          "minLength": 1
         }
       },
-      "allOf": [
+      "anyOf": [
+        {
+          "oneOf": [
+            {
+              "required": ["minAvailable"]
+            },
+            {
+              "required": ["maxUnavailable"]
+            }
+          ]
+        },
         {
           "not": {
-            "properties": {
-              "minAvailable": {
-                "type": "integer",
-                "minLength": 1
+            "allOf": [
+              {
+                "required": ["minAvailable"]
               },
-              "maxUnavailable": {
-                "type": "integer",
-                "minLength": 1
+              {
+                "required": ["maxUnavailable"]
               }
-            }
+            ]
           }
         }
       ],

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -109,8 +109,9 @@ additionalAnnotations: {}
 policyServer:
   enabled: true
   replicaCount: 1
-  minAvailable: ""
-  maxUnavailable: ""
+  # Only one of minAvailable,maxUnavailable can be enabled:
+  # minAvailable: 30%
+  # maxUnavailable: 1
   image:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     repository: "kubewarden/policy-server"


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/helm-charts/pull/505

Revert to using string for `minAvailable, maxUnavailable`.
Fix the schema to only accept either `minAvailable` only, `maxUnavailable` only, or neither (XOR).


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested by consuming the following values:
```
recommendedPolicies:
  enabled: True
  defaultPolicyMode: monitor
policyServer:
  minAvailable: "20%"
  maxUnavailable: "1"

```

Which results on:

```
$ helm lint ./charts/kubewarden-defaults --values myvalues.yaml
==> Linting ./charts/kubewarden-defaults
[ERROR] values.yaml: - policyServer: Must validate at least one schema (anyOf)
- policyServer: Must validate one and only one schema (oneOf)

[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
kubewarden-defaults:
- policyServer: Must validate at least one schema (anyOf)
- policyServer: Must validate one and only one schema (oneOf)


Error: 1 chart(s) linted, 1 chart(s) failed
```

Yet notice there's no pretty error. 

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

This change is backwards compatible with released charts.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
