### PR TITLE
fix: generate and use ecdsa private keys

### DIFF
--- a/charts/kubewarden-controller/templates/webhooks.yaml
+++ b/charts/kubewarden-controller/templates/webhooks.yaml
@@ -1,7 +1,7 @@
 # generate certificates
 {{ $dnsName :=  printf "%s-webhook-service.%s.svc" (include "kubewarden-controller.fullname" .) .Release.Namespace }}
-{{ $ca := genCA "kubewarden-controller-ca" 365 }}
-{{ $cert := genSignedCert $dnsName nil ( list $dnsName ) 3650 $ca }}
+{{ $ca := genCAWithKey "kubewarden-controller-ca" 365 (genPrivateKey "ecdsa") }}
+{{ $cert := genSignedCertWithKey $dnsName nil ( list $dnsName ) 3650 $ca (genPrivateKey "ecdsa") }}
 {{ $caCert := ($ca.Cert | b64enc) }}
 {{ $oldCaCert := "" }}
 {{ $caBundle := $caCert }}


### PR DESCRIPTION
## Description
Create and use ECDSA private keys when generating CA and leaf certificates.
The same was done in the controller in  https://github.com/kubewarden/kubewarden-controller/pull/866

