### PR TITLE
fix: wrong certificates validity duration

### DIFF
--- a/charts/kubewarden-controller/templates/webhooks.yaml
+++ b/charts/kubewarden-controller/templates/webhooks.yaml
@@ -1,7 +1,7 @@
 # generate certificates
 {{ $dnsName :=  printf "%s-webhook-service.%s.svc" (include "kubewarden-controller.fullname" .) .Release.Namespace }}
-{{ $ca := genCAWithKey "kubewarden-controller-ca" 365 (genPrivateKey "ecdsa") }}
-{{ $cert := genSignedCertWithKey $dnsName nil ( list $dnsName ) 3650 $ca (genPrivateKey "ecdsa") }}
+{{ $ca := genCAWithKey "kubewarden-controller-ca" 3650 (genPrivateKey "ecdsa") }}
+{{ $cert := genSignedCertWithKey $dnsName nil ( list $dnsName ) 365 $ca (genPrivateKey "ecdsa") }}
 {{ $caCert := ($ca.Cert | b64enc) }}
 {{ $oldCaCert := "" }}
 {{ $caBundle := $caCert }}


### PR DESCRIPTION
## Description

The validity duration for the root CA and other certificate generated in the webhooks.yaml are inverted. In the current code, the root CA expiration is less than the certificate used by the controller, which is signed by the root CA. However, the root CA validity should be 10 years (3650 days) and the certificate used by the controller webserver should be 1 year (365 days). This commit fixes the issue by inverting the validity duration in both certificates.


Related to https://github.com/kubewarden/kubewarden-controller/issues/7
