### PR TITLE
chore: Shorten `del-pre-1-17-webhook-srv-cert` hook name

### DIFF
--- a/charts/kubewarden-controller/templates/post-install-hook.yaml
+++ b/charts/kubewarden-controller/templates/post-install-hook.yaml
@@ -100,7 +100,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-delete-pre-1-17-webhook-server-cert"
+  name: "{{ .Release.Name }}-del-pre-1-17-webhook-srv-cert"
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
@@ -114,7 +114,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "{{ .Release.Name }}-delete-pre-1-17-webhook-server-cert"
+      name: "{{ .Release.Name }}-del-pre-1-17-webhook-srv-cert"
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -129,7 +129,7 @@ spec:
 {{ toYaml .Values.preDeleteHook.podSecurityContext | indent 8 }}
       {{- end }}
       containers:
-        - name: delete-pre-1-17-webhook-server-cert
+        - name: del-pre-1-17-webhook-srv-cert
           image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
           command: ["kubectl", "--namespace", "{{ .Release.Namespace }}", "delete", "--ignore-not-found", "secret", "webhook-server-cert"]
           {{- if .Values.preDeleteHook.containerSecurityContext }}


### PR DESCRIPTION

## Description

With long enough release names (such as the ones used by Rancher), the Job metadata.name goes over the 63 chars.

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix 
```
Error: failed post-install: warning: Hook post-install kubewarden-controller/templates/post-install-hook.yaml failed: 1 error occurred:
	* Job.batch "rancher-kubewarden-controller-delete-pre-1-17-webhook-server-cert" is invalid: spec.template.labels: Invalid value: "rancher-kubewarden-controller-delete-pre-1-17-webhook-server-cert": must be no more than 63 characters
```

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
