### PR TITLE
fix: set default value for old CA field when missing.

### DIFF
--- a/charts/kubewarden-controller/templates/webhooks.yaml
+++ b/charts/kubewarden-controller/templates/webhooks.yaml
@@ -13,7 +13,11 @@
 {{ if $caSecret }}
 {{ $caCert = (index $caSecret.data "ca.crt") }}
 {{ $caPrivateKey = (index $caSecret.data "ca.key") }}
-{{ $oldCaCert = (index $caSecret.data "old-ca.crt") }}
+# If the old CA certificate is missing, set it to "". This is to avoid issues
+# with b64dec when the old CA certificate is not present in the secret. This
+# can happen after an upgrade. The old CA field is removed from the secret
+# because it's empty. Therefore, a future upgrade can fail.
+{{ $oldCaCert = (index $caSecret.data "old-ca.crt" | default "") }}
 {{ $caBundle = printf "%s%s" ($caCert | b64dec) ($oldCaCert | b64dec) | b64enc }}
 {{ end }}
 {{ $serverCertSecret := (lookup "v1" "Secret" .Release.Namespace "kubewarden-webhook-server-cert") }}


### PR DESCRIPTION
## Description

Updates the webhooks.yaml template to set a default value "" to the old CA certificate when it's missing. This can happen because the empty value in the secret is removed during the upgrade. Therefore, in a future upgrade the b64enc function fails because the value is nil.

Fix https://github.com/kubewarden/helm-charts/issues/523