### PR TITLE
fix(kubewarden-controller): missing indentation in Chart.yaml

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -35,7 +35,7 @@ annotations:
   catalog.cattle.io/display-name: Kubewarden # Only for Charts with custom UI
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
-catalog.cattle.io/auto-install: kubewarden-crds=1.9.0-rc3
+  catalog.cattle.io/auto-install: kubewarden-crds=1.9.0-rc3
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
   # The following two will create a UI warning if the request is not available in cluster
   # Assume the most standard setup for your chart. These can be strings with amounts, ie 64Mi or 2Gi are both valid.


### PR DESCRIPTION
## Description

Fixes wrong indentation in kubewarden-controller chart's `Chart.yaml`