### PR TITLE
fix: allow audit-scanner to scan group policies

### DIFF
--- a/charts/kubewarden-controller/templates/rbac.yaml
+++ b/charts/kubewarden-controller/templates/rbac.yaml
@@ -214,9 +214,13 @@ rules:
   - policies.kubewarden.io
   resources:
   - clusteradmissionpolicies
+  - clusteradmissionpolicygroups
   - admissionpolicies
+  - admissionpolicygroups
   - clusteradmissionpolicies/status
+  - clusteradmissionpolicygroups/status
   - admissionpolicies/status
+  - admissionpolicygroups/status
   - policyservers
   - policyservers/status
   verbs:


### PR DESCRIPTION
The service account used by the audit-scanner process must be able to access group policies (both cluster and namespaced ones).

I've tested the fix locally and it works.
