### PR TITLE
fix(kubewarden-controller): webhooks template policy group resources plural names

### DIFF
--- a/charts/kubewarden-controller/templates/webhooks.yaml
+++ b/charts/kubewarden-controller/templates/webhooks.yaml
@@ -101,7 +101,7 @@ webhooks:
       - CREATE
       - UPDATE
       resources:
-      - clusteradmissionpoliciesgroup
+      - clusteradmissionpolicygroups
   sideEffects: None
 - admissionReviewVersions:
     - v1
@@ -167,7 +167,7 @@ webhooks:
       - CREATE
       - UPDATE
       resources:
-      - admissionpoliciesgroup
+      - admissionpolicygroups
   sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -221,7 +221,7 @@ webhooks:
       - CREATE
       - UPDATE
       resources:
-      - clusteradmissionpoliciesgroup
+      - clusteradmissionpolicygroups
   sideEffects: None
 - admissionReviewVersions:
   - v1
@@ -265,7 +265,7 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - admissionpoliciesgroup
+    - admissionpolicygroups
   sideEffects: None
 - admissionReviewVersions:
   - v1


### PR DESCRIPTION
## Description

Fixes a webhook misconfiguration caused by the wrong policy group plural names. 