### PR TITLE
deps: Correctly consume audit-scanner v1.17.0

### DIFF
--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -194,7 +194,7 @@ auditScanner:
     # The registry is defined in the common.cattle.systemDefaultRegistry value
     # kubectl image to be used in the pre-delete helm hook
     repository: "kubewarden/audit-scanner"
-    tag: v1.17.1
+    tag: v1.17.0
     pullPolicy: IfNotPresent
   cronJob:
     schedule: "*/60 * * * *" # every 60 minutes


### PR DESCRIPTION
## Description

v1.17.1 doesn't exist yet, it was incorrectly bumped by the update-cli automation PR.

<!-- Please provide the link to the GitHub issue you are addressing -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

After merging this, the release for kubewarden-controller version 3.0.1 should succeed.


### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
