### PR TITLE
fix(kubewarden-defaults): set `failurePolicy: Ignore` if mode == "monitor"

### DIFF
--- a/charts/kubewarden-defaults/templates/_helpers.tpl
+++ b/charts/kubewarden-defaults/templates/_helpers.tpl
@@ -76,3 +76,11 @@ namespaceSelector:
 {{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "policy_failure_policy" -}}
+{{- if eq .Values.recommendedPolicies.defaultPolicyMode "protect" -}}
+Fail
+{{- else -}}
+Ignore
+{{- end -}}
+{{- end -}}

--- a/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
+++ b/charts/kubewarden-defaults/templates/allow-privileged-escalation-policy.yaml
@@ -12,6 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.allowPrivilegeEscalationPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
+  failurePolicy: {{ template "policy_failure_policy" . }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module.repository }}:{{ .Values.recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:

--- a/charts/kubewarden-defaults/templates/capabilities-policy.yaml
+++ b/charts/kubewarden-defaults/templates/capabilities-policy.yaml
@@ -12,6 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.capabilitiesPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
+  failurePolicy: {{ template "policy_failure_policy" . }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.capabilitiesPolicy.module.repository }}:{{ .Values.recommendedPolicies.capabilitiesPolicy.module.tag }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:

--- a/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-namespace-policy.yaml
@@ -12,6 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.hostNamespacePolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
+  failurePolicy: {{ template "policy_failure_policy" . }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.hostNamespacePolicy.module.repository }}:{{ .Values.recommendedPolicies.hostNamespacePolicy.module.tag }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:

--- a/charts/kubewarden-defaults/templates/host-path-policy.yaml
+++ b/charts/kubewarden-defaults/templates/host-path-policy.yaml
@@ -12,6 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.hostPathsPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
+  failurePolicy: {{ template "policy_failure_policy" . }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.hostPathsPolicy.module.repository }}:{{ .Values.recommendedPolicies.hostPathsPolicy.module.tag }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:

--- a/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
+++ b/charts/kubewarden-defaults/templates/pod-privileged-policy.yaml
@@ -12,6 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.podPrivilegedPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
+  failurePolicy: {{ template "policy_failure_policy" . }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.podPrivilegedPolicy.module.repository }}:{{ .Values.recommendedPolicies.podPrivilegedPolicy.module.tag }}
 
 {{ include "policy-namespace-selector" . | indent 2}}

--- a/charts/kubewarden-defaults/templates/user-group-policy.yaml
+++ b/charts/kubewarden-defaults/templates/user-group-policy.yaml
@@ -12,6 +12,7 @@ metadata:
   name: {{ $.Values.recommendedPolicies.userGroupPolicy.name }}
 spec:
   mode: {{ $.Values.recommendedPolicies.defaultPolicyMode }}
+  failurePolicy: {{ template "policy_failure_policy" . }}
   module: {{ template "policy_default_registry" . }}{{ .Values.recommendedPolicies.userGroupPolicy.module.repository }}:{{ .Values.recommendedPolicies.userGroupPolicy.module.tag }}
 {{ include "policy-namespace-selector" . | indent 2}}
   rules:

--- a/charts/kubewarden-defaults/tests/failure_policy_test.yaml
+++ b/charts/kubewarden-defaults/tests/failure_policy_test.yaml
@@ -1,0 +1,25 @@
+suite: set failurePolicy based upon mode
+templates:
+  - allow-privileged-escalation-policy.yaml
+  - capabilities-policy.yaml
+  - host-namespace-policy.yaml
+  - host-path-policy.yaml
+  - pod-privileged-policy.yaml
+  - user-group-policy.yaml
+tests:
+  - it: "should ignore on webhook failures if in monitor mode"
+    set:
+      recommendedPolicies.enabled: true
+      recommendedPolicies.defaultPolicyMode: "monitor"
+    asserts:
+      - equal:
+          path: spec.failurePolicy
+          value: Ignore
+  - it: "should reject on webhook failures if in protect mode"
+    set:
+      recommendedPolicies.enabled: true
+      recommendedPolicies.defaultPolicyMode: "protect"
+    asserts:
+      - equal:
+          path: spec.failurePolicy
+          value: Fail


### PR DESCRIPTION
## Description
Currently the default set of policies are applied in monitor mode, but cause all pods to be rejected if the kubewarden service is down. This should not be the case if the user's intention is to monitor instead of protect.

## Test
I've added a couple of tests to a new suite for kubewarden-defaults to check this behaves as expected

## Additional Information

### Tradeoff
N/A 

### Potential improvement
Prevent catastrophic failure when kubewarden service is unavailable if in monitor mode