### PR TITLE
added imagepullsecrets

### DIFF
--- a/charts/kubewarden-controller/templates/post-install-hook.yaml
+++ b/charts/kubewarden-controller/templates/post-install-hook.yaml
@@ -35,6 +35,10 @@ spec:
       securityContext:
 {{ toYaml .Values.preDeleteHook.podSecurityContext | indent 8 }}
       {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: post-install-job
           image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
@@ -86,6 +90,10 @@ spec:
       securityContext:
 {{ toYaml .Values.preDeleteHook.podSecurityContext | indent 8 }}
       {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: delete-pre-1-11-policyreports-job
           image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
@@ -94,7 +102,7 @@ spec:
           securityContext:
 {{ toYaml .Values.preDeleteHook.containerSecurityContext | indent 12 }}
           {{- end }}
-          
+
 ---
 # Delete pre 1.17 webhook certificates secret.
 apiVersion: batch/v1
@@ -127,6 +135,10 @@ spec:
       {{- if .Values.preDeleteHook.podSecurityContext }}
       securityContext:
 {{ toYaml .Values.preDeleteHook.podSecurityContext | indent 8 }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
         - name: del-pre-1-17-webhook-srv-cert


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #556

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

add image pull secrets to a values file:
```

imagePullSecrets:
  - name: mySecret
```

```shell
helm install --wait -n kubewarden kubewarden-controller charts/kubewarden-controller --values myvalues.yaml
```

Images of the post-install-hook can be pulled even if the private registry needs authentication.

## Additional Information
if imagePullSecrets are not set the part will be ignored and not created.

### Tradeoff

None Known

### Potential improvement

None Known
