### PR TITLE
ci: Automatically copy {,cluster}admissionpolicygroups YAMLs to kubewarden-crds

### DIFF
--- a/updatecli/scripts/install_crds.sh
+++ b/updatecli/scripts/install_crds.sh
@@ -5,6 +5,8 @@ if [ -f "/tmp/crds-controller.tar.gz" ]; then
 	find . -maxdepth 1 -name "*_policyserver*" -exec mv \{\} charts/kubewarden-crds/templates/policyservers.yaml \;
 	find . -maxdepth 1 -name "*_admissionpolicies*" -exec mv \{\} charts/kubewarden-crds/templates/admissionpolicies.yaml \;
 	find . -maxdepth 1 -name "*_clusteradmissionpolicies*" -exec mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicies.yaml \;
+	find . -maxdepth 1 -name "*_admissionpolicygroups*" -exec mv \{\} charts/kubewarden-crds/templates/admissionpolicygroups.yaml \;
+	find . -maxdepth 1 -name "*_clusteradmissionpolicygroups*" -exec mv \{\} charts/kubewarden-crds/templates/clusteradmissionpolicygroups.yaml \;
 fi
 
 if [ -f "/tmp/crds-audit-scanner.tar.gz" ]; then


### PR DESCRIPTION
## Description

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

We forgot to automatically move the {,cluster}admissionpolicygroups YAMLs to kubewarden-crds when consuming the controller CRDs.tar.gz artifact.

This resurfaced because we are now updating them with the short names.
See https://github.com/kubewarden/helm-charts/pull/561/commits/85adc7364d103f4491a36105df94209a05b43ab0.

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
