### PR TITLE
ci: Fix OCI signatures

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -165,7 +165,7 @@ jobs:
             chart_name=$(helm show chart $chart | yq '.name' | sed 's/"//g')
             chart_version=$(helm show chart $chart | yq '.version' | sed 's/"//g')
             package_file=".cr-release-packages/$chart_name-$chart_version.tgz"
-            push_output=$(helm push $package_file "oci://$REGISTRY/charts")
+            push_output=$(helm push $package_file "oci://$REGISTRY/charts" 2>&1)
             chart_url=$(echo $push_output | sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\1\@\2/p')
             cosign sign --yes "$chart_url"
           done


### PR DESCRIPTION
## Description

`helm push` has changed behavior and now it only outputs the pushed image and digest to stderr. Capture it.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

Test run: https://github.com/viccuad/helm-charts/actions/runs/11483505939/job/31959091041

This fix will not take effect for beta1, which will be left unsigned.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
