### PR TITLE
ci: Generate and push provenance attestations for charts

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -1,17 +1,18 @@
-# This action releases the kubewarden-controller helm chart
-# The action must run on each commit done against master, however
+# This action releases the kubewarden Helm charts.
+# The action must run on each commit done against main, however
 # a new release will be performed **only** when a change occurs inside
 # of the `charts` directory.
 #
-# When the helm chart is changed, this action will:
-#   * Create a new GitHub release named: kubwarden-controller-chart
+# When the helm charts are changed, this action will, for each chart:
+#   * Create a new GitHub release: e.g. kubwarden-controller-chart.
 #   * This release has a kubwarden-controller-chart.tar.gz asset associated with
-#     it. This is the actual helm chart
+#     it. This is the actual Helm chart.
 #   * Update the `index.yaml` file inside of the `gh-pages` branch. This is the
-#     index of the helm chart repository, which we serve through GitHub pages
-#   * Update the docs shown https://charts.kubewarden.io, on the `gh-pages`
+#     index of our https Helm chart repository, which we serve through GitHub pages.
+#   * Update the docs shown at https://charts.kubewarden.io, on the `gh-pages`
 #     branch. This is the README files of the chart(s), served also through
-#     GitHub pages
+#     GitHub pages.
+#   * Push the chart, signed and with attestation, to ghcr.io OCI registry.
 #
 # = FAQ
 #
@@ -25,7 +26,7 @@
 #
 # Yes, we even got that to work. However, what we really want to do is the
 # ability to tag the releases of the kubewarden-controller and its helm chart
-# in an independent way. Which what the official GitHub action already does.
+# in an independent way. Which the official GitHub action already does.
 
 name: Release helm chart
 

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -41,6 +41,7 @@ jobs:
       id-token: write
       packages: write
       contents: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -148,24 +149,86 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate, sign and publish charts in OCI registry
+      - name: Publish and sign kubewarden-crds chart in OCI registry
         shell: bash
         run: |
-          set -e
+          set -ex
+          chart_name=kubewarden-crds
+
           # .cr-release-packages is the directory used by the Helm releaser from a previous step
-          chart_directory=.cr-release-packages
-          if [ ! -d "$chart_directory" ]; then
-            echo "$chart_directory does not exist. Assuming no charts update"
+          chart_path=.cr-release-packages/${chart_name}-*.tgz
+          if [ ! -f $chart_path ]; then
+            echo "$chart_path does not exist. Assuming no charts update"
             exit 0
           fi
+          REGISTRY="ghcr.io/$GITHUB_REPOSITORY_OWNER/charts"
+          echo "REGISTRY=${REGISTRY}" >> "$GITHUB_ENV"
+          push_output=$(helm push $chart_path "oci://$REGISTRY" 2>&1)
+          chart_url=$(echo $push_output | sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\1\@\2/p')
+          digest=$(echo $push_output | sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\2/p')
+          echo "DIGEST_${chart_name}=${digest}" >> "$GITHUB_ENV"
+          cosign sign --yes "$chart_url"
 
-          REGISTRY="ghcr.io/$GITHUB_REPOSITORY_OWNER"
-          charts=$(find $chart_directory -maxdepth 1 -mindepth 1 -type f)
-          for chart in $charts; do
-            chart_name=$(helm show chart $chart | yq '.name' | sed 's/"//g')
-            chart_version=$(helm show chart $chart | yq '.version' | sed 's/"//g')
-            package_file=".cr-release-packages/$chart_name-$chart_version.tgz"
-            push_output=$(helm push $package_file "oci://$REGISTRY/charts")
-            chart_url=$(echo $push_output | sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\1\@\2/p')
-            cosign sign --yes "$chart_url"
-          done
+      - name: Generate provenance attestation for kubewarden-crds chart and push to OCI
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
+        if: env.DIGEST_kubewarden-crds != ''
+        with:
+          push-to-registry: true
+          subject-name: ${{ env.REGISTRY}}/kubewarden-crds
+          subject-digest: ${{ env.DIGEST_kubewarden-crds }}
+
+      - name: Publish and sign kubewarden-controller chart in OCI registry
+        shell: bash
+        run: |
+          set -ex
+          chart_name=kubewarden-controller
+
+          # .cr-release-packages is the directory used by the Helm releaser from a previous step
+          chart_path=.cr-release-packages/${chart_name}-*.tgz
+          if [ ! -f $chart_path ]; then
+            echo "$chart_path does not exist. Assuming no charts update"
+            exit 0
+          fi
+          REGISTRY="ghcr.io/$GITHUB_REPOSITORY_OWNER/charts"
+          echo "REGISTRY=${REGISTRY}" >> "$GITHUB_ENV"
+          push_output=$(helm push $chart_path "oci://$REGISTRY" 2>&1)
+          chart_url=$(echo $push_output | sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\1\@\2/p')
+          digest=$(echo $push_output | sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\2/p')
+          echo "DIGEST_${chart_name}=${digest}" >> "$GITHUB_ENV"
+          cosign sign --yes "$chart_url"
+
+      - name: Generate provenance attestation for kubewarden-controller chart and push to OCI
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
+        if: env.DIGEST_kubewarden-controller != ''
+        with:
+          push-to-registry: true
+          subject-name: ${{ env.REGISTRY}}/kubewarden-controller
+          subject-digest: ${{ env.DIGEST_kubewarden-controller }}
+
+      - name: Publish and sign kubewarden-defaults chart in OCI registry
+        shell: bash
+        run: |
+          set -ex
+          chart_name=kubewarden-defaults
+
+          # .cr-release-packages is the directory used by the Helm releaser from a previous step
+          chart_path=.cr-release-packages/${chart_name}-*.tgz
+          if [ ! -f $chart_path ]; then
+            echo "$chart_path does not exist. Assuming no charts update"
+            exit 0
+          fi
+          REGISTRY="ghcr.io/$GITHUB_REPOSITORY_OWNER/charts"
+          echo "REGISTRY=${REGISTRY}" >> "$GITHUB_ENV"
+          push_output=$(helm push $chart_path "oci://$REGISTRY" 2>&1)
+          chart_url=$(echo $push_output | sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\1\@\2/p')
+          digest=$(echo $push_output | sed -n 's/Pushed: \(.*\):.* Digest: \(.*\)$/\2/p')
+          echo "DIGEST_${chart_name}=${digest}" >> "$GITHUB_ENV"
+          cosign sign --yes "$chart_url"
+
+      - name: Generate provenance attestation for kubewarden-defaults chart and push to OCI
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
+        if: env.DIGEST_kubewarden-defaults != ''
+        with:
+          push-to-registry: true
+          subject-name: ${{ env.REGISTRY}}/kubewarden-defaults
+          subject-digest: ${{ env.DIGEST_kubewarden-defaults }}


### PR DESCRIPTION
## Description

Closes https://github.com/kubewarden/helm-charts/issues/565.

<!-- Please provide the link to the GitHub issue you are addressing -->
Use actions/attest-build-provenance to generate and upload the provenance attestation as an OCI artifact layer.

Since we need the digest of each helm chart OCI artifact so we can push the attestation, unroll the `for helm push` that existed before. Decided to duplicate those bash scripts instead of creating a new script and makefile target because they basically set the `GITHUB_ENV` vars and call `helm push` and `cosign `with them.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Successful run: https://github.com/viccuad/helm-charts/actions/runs/11484306246/job/31961771613
https://github.com/viccuad/helm-charts/attestations

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
