### PR TITLE
feat: extra OPTEL collector configuration.

### DIFF
--- a/charts/kubewarden-controller/questions.yaml
+++ b/charts/kubewarden-controller/questions.yaml
@@ -115,47 +115,92 @@ questions:
       Number of replicas of the Controller Deployment
     group: "Controller HA"
   # Telemetry:
-  - variable: "telemetry.metrics.enabled"
+  - variable: "telemetry.mode"
+    type: enum
+    options:
+      - "sidecar"
+      - "custom"
+    default: "sidecar"
+    required: true
+    label: Telemetry mode
+    description: |
+      Choose the telemetry mode. Sidecar mode will deploy an OpenTelemetry Collector
+      as a sidecar container in the Kubewarden Controller pod. Custom mode will allow
+      you to configure the OpenTelemetry Collector.
+    group: "Telemetry"
+  - variable: "telemetry.metrics"
     type: boolean
     default: false
     required: true
     label: Enable Metrics
     description: |
       Enable metrics collection for all Policy Servers and the Kubewarden Controller.
-      Important: Requires OpenTelemetry CRDs available
+      Important: Requires OpenTelemetry CRDs available.
     group: "Telemetry"
-    subquestions:
-      - variable: "telemetry.metrics.port"
-        type: string
-        default: "8080"
-        label: Port
-        description: |
-          Port of the Prometheus exporter and PolicyServer metrics service
-        group: "Telemetry"
-        show_if: "telemetry.metrics.enabled=true"
-  - variable: "telemetry.tracing.enabled"
+  - variable: "telemetry.tracing"
     type: boolean
     default: false
     required: true
     label: Enable Tracing
     description: |
       Enable tracing collection for all PolicyServers.
-      Important: Requires OpenTelemetry CRDs available
+      Important: Requires OpenTelemetry CRDs available.
     group: "Telemetry"
-    subquestions:
-      - variable: "telemetry.tracing.jaeger.endpoint"
-        type: string
-        default: my-open-telemetry-collector.jaeger.svc.cluster.local:4317
-        label: Jaeger endpoint configuration
-        description: |
-          Configuration of the OTLP/Jaeger exporter
-        group: "Telemetry"
-        show_if: "telemetry.tracing.enabled=true"
-      - variable: "telemetry.tracing.jaeger.tls.insecure"
-        type: boolean
-        default: false
-        label: Jaeger endpoint insecure TLS configuration
-        description: |
-          Important: Insecure, not for production usage
-        group: "Telemetry"
-        show_if: "telemetry.tracing.enabled=true"
+  - variable: "telemetry.sidecar.metrics.port"
+    type: string
+    default: "8080"
+    label: Port
+    description: |
+      Port of the Prometheus exporter and PolicyServer metrics service.
+    group: "Telemetry"
+    show_if: "telemetry.mode=sidecar"
+  - variable: "telemetry.sidecar.tracing.jaeger.endpoint"
+    type: string
+    default: my-open-telemetry-collector.jaeger.svc.cluster.local:4317
+    label: Jaeger endpoint configuration
+    description: |
+      Configuration of the OTLP/Jaeger exporter.
+    group: "Telemetry"
+    show_if: "telemetry.mode=sidecar"
+  - variable: "telemetry.sidecar.tracing.jaeger.tls.insecure"
+    type: boolean
+    default: false
+    label: Jaeger endpoint insecure TLS configuration
+    description: |
+      Important: Insecure, not for production usage.
+    group: "Telemetry"
+    show_if: "telemetry.mode=sidecar"
+  - variable: "telemetry.custom.endpoint"
+    type: string
+    default: ""
+    label: OpenTelemetry endpoint
+    description: |
+      Endpoint of the OpenTelemetry collector.
+    group: "Telemetry"
+    show_if: "telemetry.mode=custom"
+  - variable: "telemetry.custom.insecure"
+    type: boolean
+    default: false
+    label: Insecure communication
+    description: |
+      Disable TLS verification for the OpenTelemetry collector.
+    group: "Telemetry"
+    show_if: "telemetry.mode=custom"
+  - variable: "telemetry.custom.otelCollectorCertificateSecret"
+    type: string
+    default: ""
+    label: Certificate secret
+    description: |
+      Secret containing the certificate for the OpenTelemetry collector.
+      The secret should contain the key `ca.crt`.
+    group: "Telemetry"
+    show_if: "telemetry.mode=custom && telemetry.custom.insecure=false"
+  - variable: "telemetry.custom.otelCollectorClientCertificateSecret"
+    type: string
+    default: ""
+    label: Client certificate secret
+    description: |
+      Secret containing the client certificate for the OpenTelemetry collector (mTLS).
+      The secret should contain the keys `tls.crt` and `tls.key`.
+    group: "Telemetry"
+    show_if: "telemetry.mode=custom && telemetry.custom.insecure=false"

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -18,8 +18,10 @@ spec:
         {{- range keys .Values.podAnnotations }}
         {{ . | quote }}: {{ get $.Values.podAnnotations . | quote}}
         {{- end }}
-        {{- if or .Values.telemetry.metrics.enabled .Values.telemetry.tracing.enabled}}
+        {{- if or .Values.telemetry.metrics .Values.telemetry.tracing }}
+        {{- if eq .Values.telemetry.mode "sidecar" }}
         "sidecar.opentelemetry.io/inject": "true"
+        {{- end }}
         {{- end }}
         {{- include "kubewarden-controller.annotations" . | nindent 8 }}
       labels:
@@ -46,21 +48,55 @@ spec:
         - --leader-elect
         - --deployments-namespace={{ .Release.Namespace }}
         - --webhook-service-name={{ include "kubewarden-controller.fullname" . }}-webhook-service
-       {{- if .Values.telemetry.metrics.enabled }}
-        - --enable-metrics
-       {{- end }}
-       {{- if .Values.telemetry.tracing.enabled }}
-        - --enable-tracing
-       {{- end }}
         - --always-accept-admission-reviews-on-deployments-namespace
         - --zap-log-level={{ .Values.logLevel }}
+       {{- if or .Values.telemetry.metrics .Values.telemetry.tracing }}
+       {{- if eq .Values.telemetry.mode "sidecar" }}
+        - --enable-otel-sidecar
+       {{- end }}
+       {{- if .Values.telemetry.metrics }}
+        - --enable-metrics
+       {{- end }}
+       {{- if .Values.telemetry.tracing }}
+        - --enable-tracing
+       {{- end }}
+        {{- if and (not .Values.telemetry.custom.insecure) .Values.telemetry.custom.otelCollectorCertificateSecret }}
+        - --opentelemetry-certificate-secret={{ .Values.telemetry.custom.otelCollectorCertificateSecret }}
+        {{- end }}
+        {{- if and (not .Values.telemetry.custom.insecure) .Values.telemetry.custom.otelCollectorClientCertificateSecret }}
+        - --opentelemetry-client-certificate-secret={{ .Values.telemetry.custom.otelCollectorClientCertificateSecret }}
+        {{- end }}
+       {{- end }}
         command:
         - /manager
-        {{- if .Values.telemetry.metrics.enabled }}
         env:
+        {{- if and .Values.telemetry.metrics (eq .Values.telemetry.mode "sidecar") }}
           - name: KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT
-            value: "{{ .Values.telemetry.metrics.port | default 8080 }}"
+            value: "{{ .Values.telemetry.sidecar.metrics.port | default 8080 }}"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "https://localhost:4317"
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: "true"
         {{- end }}
+        {{- if or .Values.telemetry.metrics .Values.telemetry.tracing }}
+        {{- if eq .Values.telemetry.mode "custom" }}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{.Values.telemetry.custom.endpoint}}
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: {{ .Values.telemetry.custom.insecure | default false | quote }}
+        {{- if and (not .Values.telemetry.custom.insecure) .Values.telemetry.custom.otelCollectorCertificateSecret }}
+          - name: OTEL_EXPORTER_OTLP_CERTIFICATE
+            value: /kubewarden/otel-collector-certs/ca.crt 
+        {{- end }}
+        {{- if and (not .Values.telemetry.custom.insecure) .Values.telemetry.custom.otelCollectorClientCertificateSecret }}
+          - name: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE
+            value: /kubewarden/otel-collector-client-certs/tls.crt
+          - name: OTEL_EXPORTER_OTLP_CLIENT_KEY
+            value: /kubewarden/otel-collector-client-certs/tls.key
+        {{- end }}
+        {{- end }}
+        {{- end }}
+
         image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:
@@ -87,6 +123,16 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        {{- if and (not .Values.telemetry.custom.insecure) .Values.telemetry.custom.otelCollectorCertificateSecret }}
+        - mountPath: /kubewarden/otel-collector-certs
+          name: otel-collector-certificate
+          readOnly: true
+        {{- end }}
+        {{- if and (not .Values.telemetry.custom.insecure) .Values.telemetry.custom.otelCollectorClientCertificateSecret }}
+        - mountPath: /kubewarden/otel-collector-client-certs
+          name: otel-collector-client-certificate
+          readOnly: true
+        {{- end }}
         ports:
         - containerPort: 9443
           name: webhook-server
@@ -96,6 +142,26 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubewarden-webhook-server-cert
+      {{- if and (not .Values.telemetry.custom.insecure) .Values.telemetry.custom.otelCollectorCertificateSecret }}
+      - name: otel-collector-certificate
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.telemetry.custom.otelCollectorCertificateSecret }}
+          items:
+            - key: ca.crt
+              path: ca.crt
+      {{- end }}
+      {{- if and (not .Values.telemetry.custom.insecure) .Values.telemetry.custom.otelCollectorClientCertificateSecret }}
+      - name: otel-collector-client-certificate
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.telemetry.custom.otelCollectorClientCertificateSecret }}
+          items:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+      {{- end }}
       {{- if .Values.podSecurityContext }}
       securityContext:
 {{ toYaml .Values.podSecurityContext | indent 8 }}

--- a/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
+++ b/charts/kubewarden-controller/templates/opentelemetry-collector.yaml
@@ -1,4 +1,5 @@
-{{ if or .Values.telemetry.metrics.enabled .Values.telemetry.tracing.enabled }}
+{{ if or .Values.telemetry.metrics .Values.telemetry.tracing }}
+{{ if eq .Values.telemetry.mode "sidecar" }}
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
@@ -18,32 +19,33 @@ spec:
     processors:
       batch: {}
     exporters:
-      {{- if and .Values.telemetry.tracing.enabled .Values.telemetry.tracing.jaeger.endpoint }}
+      {{- if and .Values.telemetry.tracing .Values.telemetry.sidecar.tracing.jaeger.endpoint }}
       otlp/jaeger:
-        endpoint: {{ .Values.telemetry.tracing.jaeger.endpoint }}
-        {{- if hasKey .Values.telemetry.tracing.jaeger "tls" }}
-        {{- if .Values.telemetry.tracing.jaeger.tls.insecure }}
+        endpoint: {{ .Values.telemetry.sidecar.tracing.jaeger.endpoint }}
+        {{- if hasKey .Values.telemetry.sidecar.tracing.jaeger "tls" }}
+        {{- if .Values.telemetry.sidecar.tracing.jaeger.tls.insecure }}
         tls:
-          insecure: {{ .Values.telemetry.tracing.jaeger.tls.insecure }}
+          insecure: {{ .Values.telemetry.sidecar.tracing.jaeger.tls.insecure }}
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if and .Values.telemetry.metrics.enabled .Values.telemetry.metrics.port }}
+      {{- if and .Values.telemetry.metrics .Values.telemetry.sidecar.metrics.port }}
       prometheus:
-        endpoint: ":{{ .Values.telemetry.metrics.port }}"
+        endpoint: ":{{ .Values.telemetry.sidecar.metrics.port }}"
       {{- end }}
     service:
       pipelines:
-        {{- if and .Values.telemetry.metrics.enabled .Values.telemetry.metrics.port }}
+        {{- if and .Values.telemetry.metrics .Values.telemetry.sidecar.metrics.port }}
         metrics:
           receivers: [otlp]
           processors: []
           exporters: [prometheus]
         {{- end }}
-        {{- if and .Values.telemetry.tracing.enabled .Values.telemetry.tracing.jaeger.endpoint }}
+        {{- if and .Values.telemetry.tracing .Values.telemetry.sidecar.tracing.jaeger.endpoint }}
         traces:
           receivers: [otlp]
           processors: [batch]
           exporters: [otlp/jaeger]
         {{- end }}
+{{ end }}
 {{ end }}

--- a/charts/kubewarden-controller/templates/post-install-hook.yaml
+++ b/charts/kubewarden-controller/templates/post-install-hook.yaml
@@ -3,7 +3,7 @@
 # pod, it cannot find a valid collector configuration. Therefore, it is necessary
 # to recreate the controller pod after the installation. This ensures that the
 # controller pod will have the OTEL collector container.
-{{ if or .Values.telemetry.metrics.enabled .Values.telemetry.tracing.enabled }}
+{{ if or .Values.telemetry.metrics .Values.telemetry.tracing }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/kubewarden-controller/templates/service.yaml
+++ b/charts/kubewarden-controller/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "kubewarden-controller.annotations" . | nindent 4 }}
 spec:
   ports:
-  {{- if .Values.telemetry.metrics.enabled }}
+  {{- if .Values.telemetry.metrics }}
   - name: metrics
     port: 8080
     targetPort: 8080

--- a/charts/kubewarden-controller/tests/telemetry_configuration_test.yaml
+++ b/charts/kubewarden-controller/tests/telemetry_configuration_test.yaml
@@ -1,0 +1,204 @@
+suite: telemetry configuration
+templates:
+  - deployment.yaml
+tests:
+  - it: "should set required configuration when connecting with remote otel collector"
+    set:
+      telemetry:
+        mode: "custom"
+        metrics: true
+        tracing: true
+        custom:
+          endpoint: "https://my-collector-collector.kubewarden.svc:4317"
+          insecure: false
+          otelCollectorCertificateSecret: "my-server-cert"
+          otelCollectorClientCertificateSecret: "my-client-cert"
+    asserts:
+      - isNullOrEmpty:
+          path: spec.template.metadata.annotations
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --enable-otel-sidecar
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --enable-metrics
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --enable-tracing
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --opentelemetry-certificate-secret=my-server-cert
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --opentelemetry-client-certificate-secret=my-client-cert
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT
+            value: "8080"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "https://my-collector-collector.kubewarden.svc:4317"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OTEL_EXPORTER_OTLP_INSECURE
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OTEL_EXPORTER_OTLP_CERTIFICATE
+            value: /kubewarden/otel-collector-certs/ca.crt 
+      - contains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE
+            value: /kubewarden/otel-collector-client-certs/tls.crt
+      - contains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OTEL_EXPORTER_OTLP_CLIENT_KEY
+            value: /kubewarden/otel-collector-client-certs/tls.key
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /kubewarden/otel-collector-certs
+            name: otel-collector-certificate
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /kubewarden/otel-collector-client-certs
+            name: otel-collector-client-certificate
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: otel-collector-certificate
+            secret:
+              defaultMode: 420
+              secretName: my-server-cert
+              items:
+                - key: ca.crt
+                  path: ca.crt
+      - contains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: otel-collector-client-certificate
+            secret:
+              defaultMode: 420
+              secretName: my-client-cert
+              items:
+                - key: tls.crt
+                  path: tls.crt
+                - key: tls.key
+                  path: tls.key
+  - it: "sidecar should be enable by default"
+    set:
+      telemetry:
+        mode: "sidecar"
+        metrics: true
+        tracing: true
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            "sidecar.opentelemetry.io/inject": "true"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --enable-otel-sidecar
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --enable-metrics
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --enable-tracing
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --opentelemetry-certificate-secret=
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --opentelemetry-client-certificate-secret=
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBEWARDEN_POLICY_SERVER_SERVICES_METRICS_PORT
+            value: "8080"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "https://localhost:4317"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OTEL_EXPORTER_OTLP_INSECURE
+            value: "true"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OTEL_EXPORTER_OTLP_CERTIFICATE
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OTEL_EXPORTER_OTLP_CLIENT_KEY
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /kubewarden/otel-collector-certs
+            name: otel-collector-certificate
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /kubewarden/otel-collector-client-certs
+            name: otel-collector-client-certificate
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: otel-collector-certificate
+            secret:
+              defaultMode: 420
+              items:
+                - key: ca.crt
+                  path: ca.crt
+      - notContains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: otel-collector-client-certificate
+            secret:
+              defaultMode: 420
+              items:
+                - key: tls.crt
+                  path: tls.crt
+                - key: tls.key
+                  path: tls.key

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -135,17 +135,65 @@ preDeleteHook:
 logLevel: info
 # open-telemetry options
 telemetry:
-  metrics:
-    enabled: false
-    # port of the prometheus exporter and PolicyServer metric service
-    port: 8080
-  tracing:
-    enabled: false
-    jaeger: {}
-    # OTLP/Jaeger endpoint to send traces to
-    # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:4317"
-    # tls:
-    #  insecure: true
+  # Kubewarden controller telemetry configuration allow two OpenTelemetry
+  # collector communication options: 
+  # - sidecar: It will create a Otel collector sidecar and configure the
+  # controller and policy server to send metrics and traces to it. 
+  # - custom: It will configure the controller and policy server to send metrics
+  # and traces to a custom collector that is not running as a sidecar.
+  
+  # The default configuration is to use the sidecar option. Therefore, if
+  # telemetry.metrics or telemetry.tracing are set to true, the sidecar will be
+  # deployed. If you want to use a custom collector, set mode to "custom"
+  mode: sidecar
+  # telemetry.metrics is used to enable/disable the metrics collection and
+  # exportation to the OpenTelemetry collector.
+  metrics: false
+  # telemetry.tracing is used to enable/disable the tracing collection and
+  # exportation to the OpenTelemetry collector.
+  tracing: false
+
+  # The following settings are mandatory to configure the OpenTelemetry
+  # exporter in the controller and policy server to send metrics and traces to
+  # a custom collector. These settings are ignored when sidecar mode is used
+  custom:
+    # telemetry.custom.endpoint is the Otel collector endpoint to send metrics and
+    # traces to. It should be in the format https://<hostname>:<port>.
+    endpoint: ""
+    # telemetry.custom.insecure is used to configure the OpenTelemetry exporter to skip
+    # the certificate validation when sending metrics and traces to a remote
+    # collector.
+    insecure: false
+    # The following settings are required to configure the OpenTelemetry exporter
+    # in the controller and policy server to send metrics and traces to a remote
+    # collector using TLS. Both secrets must be created in the same namespace
+    # where the controller is deployed.
+    #
+    # telemetry.custom.otelCollectorCertificateSecret should contains a key ca.crt
+    # storing the certifcate to validate the remote collector certificate.
+    otelCollectorCertificateSecret: ""
+    # telemetry.custom.otelCollectorClientCertificateSecret secret is optional. It's
+    # only required when the remote collector requires client authentication
+    # (mTLS). It should contains two keys: tls.crt and tls.key storing the client
+    # certificate and key respectively.
+    otelCollectorClientCertificateSecret: ""
+
+  # The following settings are used to configure the Prometheus metrics and
+  # Jaeger tracing when sidecar mode is used. Otherwise, these settings are ignored 
+  sidecar:
+    # telemetry.sidecar.metrics is used to configure the Prometheus metrics exporter
+    # in the Otel collector sidecar
+    metrics:
+      # port of the prometheus exporter and PolicyServer metric service
+      port: 8080
+    # telemetry.sidecar.tracing is used to configure the Jaeger tracing exporter
+    # in the Otel collector sidecar
+    tracing:
+      jaeger: {}
+      # OTLP/Jaeger endpoint to send traces to
+      # endpoint: "all-in-one-collector.jaeger.svc.cluster.local:4317"
+      # tls:
+      #  insecure: true
 image:
   # The registry is defined in the global.cattle.systemDefaultRegistry value
   # controller image to be used


### PR DESCRIPTION
## Description

Adds additional telemetry configuration fields to allow users to add their custom OpenTelemetry collector configuration together with the Kubewarden configuration.

Fix #573 
Needs https://github.com/kubewarden/kubewarden-controller/pull/934