### PR TITLE
fix: Set runAsUser, runAsGroup also in pre-delete-hook.yaml

### DIFF
--- a/charts/kubewarden-controller/templates/pre-delete-hook.yaml
+++ b/charts/kubewarden-controller/templates/pre-delete-hook.yaml
@@ -39,5 +39,7 @@ spec:
           command: ["kubectl", "delete", "--all", "policyservers.policies.kubewarden.io"]
           {{- if .Values.preDeleteHook.containerSecurityContext }}
           securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
 {{ toYaml .Values.preDeleteHook.containerSecurityContext | indent 12 }}
           {{- end }}


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Part of https://github.com/kubewarden/kubewarden-controller/issues/907.

This mirrors the securityContext changes of the post-install-hook.yml Job. Add `runAsUser`, `runAsGroup` for rancher/kuberlr-kubectl image.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
