### PR TITLE
ci: Open updatecli dependecy PRs as draft for workflows to trigger

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -16,10 +16,16 @@ jobs:
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@79983ec58a76fe0c87fc76f5a5c7ef8df0bb36c4 # v2.77.0
 
+      - uses: actions/create-github-app-token@vc1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Update policies and images
         id: update_policies_images
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
         run: |-
           updatecli apply --config ./updatecli/updatecli.d/update-deps.yaml \

--- a/updatecli/updatecli.d/update-deps.yaml
+++ b/updatecli/updatecli.d/update-deps.yaml
@@ -107,6 +107,7 @@ actions:
     title: "deps: Update policies, kuberlr-kubectl image"
     kind: "github/pullrequest"
     scmid: "default"
+    draft: true # for PR workflows to trigger. See https://github.com/kubewarden/helm-charts/issues/324
     spec:
       automerge: false
       mergemethod: squash


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix  https://github.com/kubewarden/helm-charts/issues/324

Open the PRs as draft, the workflows will get triggered when they are marked as ready for review.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
