### PR TITLE
deps: Revert to kubewarden/kubectl image for hooks

### DIFF
--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -205,8 +205,8 @@ preDeleteJob:
   image:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     # kuberlr-kubectl image to be used in the pre-delete helm hook.
-    repository: "rancher/kuberlr-kubectl"
-    tag: v4.0.0
+    repository: "kubewarden/kubectl"
+    tag: v1.31.0
 # kubewarden-controller deployment settings:
 podAnnotations: {}
 nodeSelector: {}


### PR DESCRIPTION
See: https://github.com/kubewarden/kubewarden-controller/issues/974

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Workaround for https://github.com/kubewarden/kubewarden-controller/issues/974

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
