### PR TITLE
Revert updatecli config from kuberlr to kubectl

### DIFF
--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -204,7 +204,7 @@ image:
 preDeleteJob:
   image:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
-    # kuberlr-kubectl image to be used in the pre-delete helm hook.
+    # kubectl image to be used in the pre-delete helm hook.
     repository: "kubewarden/kubectl"
     tag: v1.31.0
 # kubewarden-controller deployment settings:

--- a/updatecli/updatecli.d/update-deps.yaml
+++ b/updatecli/updatecli.d/update-deps.yaml
@@ -1,10 +1,10 @@
 name: Update charts with new policy versions, kubectl image
 
 sources:
-  kuberlrKubectlImageTag:
+  kubectlImageTag:
     kind: dockerimage
     spec:
-      image: ghcr.io/rancher/kuberlr-kubectl
+      image: ghcr.io/kubewarden/kubectl
       versionfilter:
         kind: semver
   allowPrivilegeEscalationPolicyTag:
@@ -46,9 +46,9 @@ sources:
 
 targets:
   updatekubectlTag:
-    name: Update kuberlr-kubectl image tag
+    name: Update kubectl image tag
     kind: yaml
-    sourceid: kuberlrKubectlImageTag
+    sourceid: kubectlImageTag
     scmid: "default"
     spec:
       file: "charts/kubewarden-controller/values.yaml"
@@ -104,14 +104,14 @@ targets:
 
 actions:
   openUpdatePR:
-    title: "deps: Update policies, kuberlr-kubectl image"
+    title: "deps: Update policies, kubectl image"
     kind: "github/pullrequest"
     scmid: "default"
     spec:
       automerge: false
       mergemethod: squash
       description: |
-        Automatic update of dependencies: policies and kuberlr-kubectl image
+        Automatic update of dependencies: policies and kubectl image
         This PR has been created by automation.
 
         NOTE: REMEMBER TO SQUASH MERGE


### PR DESCRIPTION
## Description

Partial revert of https://github.com/kubewarden/helm-charts/pull/606.

Fixes updatecli config to not bump kuberlr (https://github.com/kubewarden/helm-charts/pull/633)