### PR TITLE
Authenticate k3d registry to dockerhub

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -116,7 +116,7 @@ jobs:
         wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${{ env.K3D_VERSION }} sudo --preserve-env=TAG bash
         # Use k3d as placehoholder for default (empty) k3s version
         [[ "${{ matrix.k3s }}" != "k3d" ]] && export K3S=${{ matrix.k3s }}
-        make --directory e2e-tests cluster
+        make --directory e2e-tests cluster K3D_REGISTRY_CONFIG="${{ secrets.K3D_REGISTRY_CONFIG }}"
       env:
         CLUSTER_NAME: ${{ env.K3D_CLUSTER_NAME }}
 


### PR DESCRIPTION
## Description

E2E test failed on docker rate limit: https://github.com/kubewarden/helm-charts/actions/runs/13378490082/job/37362615670#step:7:23

This PR applies dockerhub authentication that we created for this purpose.