### PR TITLE
Disable check for workflow_run name

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -74,7 +74,7 @@ jobs:
 
     # Run schedule workflows only on original repo, not forks
     if: (github.event_name != 'schedule' || github.repository_owner == 'kubewarden') &&
-      (github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.name, 'Helm chart') ))
+      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
 
 
     strategy:


### PR DESCRIPTION
## Description

Code works on my fork but skips all tests on official repository.
Reverting to previous condition to test 1.24.0-rc1 release.

Broken release tests: https://github.com/kubewarden/helm-charts/actions/runs/14619731131