### PR TITLE
Helm chart release v1.24.0-rc2

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -23,9 +23,9 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.2.0-rc1
+version: 5.2.0-rc2
 # This is the version of Kubewarden stack
-appVersion: v1.24.0-rc1
+appVersion: v1.24.0-rc2
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
@@ -35,14 +35,14 @@ annotations:
   catalog.cattle.io/display-name: Kubewarden # Only for Charts with custom UI
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
-  catalog.cattle.io/auto-install: kubewarden-crds=1.16.0-rc1
+  catalog.cattle.io/auto-install: kubewarden-crds=1.16.0-rc2
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
   # The following two will create a UI warning if the request is not available in cluster
   # Assume the most standard setup for your chart. These can be strings with amounts, ie 64Mi or 2Gi are both valid.
   catalog.cattle.io/requests-cpu: "250m"
   catalog.cattle.io/requests-memory: "50Mi"
   catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.11.100-0" # Chart will only be available for users in the specified Rancher version(s). This _must_ use build metadata or it won't work correctly for future RC's.
-  catalog.cattle.io/upstream-version: 5.1.0
+  catalog.cattle.io/upstream-version: 5.2.0-rc2
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -22,9 +22,9 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.0-rc1
+version: 1.16.0-rc2
 # This is the version of Kubewarden stack
-appVersion: v1.24.0-rc1
+appVersion: v1.24.0-rc2
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
@@ -33,7 +33,7 @@ annotations:
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
   catalog.cattle.io/hidden: "true" # Hide specific charts. Only use on CRD charts.
-  catalog.cattle.io/upstream-version: 1.15.0
+  catalog.cattle.io/upstream-version: 1.16.0-rc2
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -22,9 +22,9 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.0-rc1
+version: 3.2.0-rc2
 # This is the version of Kubewarden stack
-appVersion: v1.23.0
+appVersion: v1.24.0-rc2
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
@@ -35,8 +35,8 @@ annotations:
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
   catalog.cattle.io/hidden: "true" # Hide specific charts. Only use on CRD charts.
-  catalog.cattle.io/upstream-version: 3.2.0-rc1
-  catalog.cattle.io/auto-install: kubewarden-crds=1.16.0-rc1
+  catalog.cattle.io/upstream-version: 3.2.0-rc2
+  catalog.cattle.io/auto-install: kubewarden-crds=1.16.0-rc2
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool


### PR DESCRIPTION

## Description

Fix https://github.com/kubewarden/helm-charts/issues/666.

Helm chart RC only, the images stay with `:1.24.0-rc1`.
Fixes some `appVersion` not being bumped, as well as their matching `catalog.cattle.io/upstream-version`

For completion, here is a comparison with the last GA releae, v1.23.0:

https://github.com/kubewarden/helm-charts/compare/kubewarden-defaults-3.1.0...viccuad:helm-charts:main

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
