### PR TITLE
feat: Add `.global.priorityClassName` to kubewarden-controller, kubewarden-defaults charts

### DIFF
--- a/charts/kubewarden-controller/questions.yaml
+++ b/charts/kubewarden-controller/questions.yaml
@@ -114,6 +114,14 @@ questions:
     description: |
       Number of replicas of the Controller Deployment
     group: "Controller HA"
+  - variable: "global.priorityClassName"
+    type: string
+    default: ""
+    required: false
+    label: Name of priorityClass
+    description: |
+      Name of the priorityClass to apply to the Kubewarden controller.
+    group: "Controller HA"
   # OpenTelemetry:
   - variable: "telemetry.mode"
     type: enum

--- a/charts/kubewarden-controller/templates/deployment.yaml
+++ b/charts/kubewarden-controller/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.global.priorityClassName }}
+      priorityClassName: {{ .Values.global.priorityClassName | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: manager
         args:

--- a/charts/kubewarden-controller/tests/priorityClassName_test.yaml
+++ b/charts/kubewarden-controller/tests/priorityClassName_test.yaml
@@ -1,0 +1,12 @@
+suite: priorityClassName configuration
+templates:
+  - deployment.yaml
+tests:
+  - it: "should set the priorityClassName when .global.priorityClassName is defined"
+    set:
+      global:
+        priorityClassName: "high-priority"
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: "high-priority"

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -58,6 +58,7 @@ global:
   #     value: "value1"
   #     effect: "NoExecute"
   tolerations: []
+  # priorityClassName: ""
   cattle:
     systemDefaultRegistry: ghcr.io
   skipNamespaces:

--- a/charts/kubewarden-defaults/questions.yaml
+++ b/charts/kubewarden-defaults/questions.yaml
@@ -50,6 +50,14 @@ questions:
     description: |
       Number of replicas of the PolicyServer Deployment
     group: "Default PolicyServer HA"
+  - variable: "global.priorityClassName"
+    type: string
+    default: ""
+    required: false
+    label: Name of priorityClass associated to the PolicyServer Pods
+    description: |
+      Name of the priorityClass to apply to default PolicyServer Pods.
+    group: "Default PolicyServer HA"
   # no-privilege-escalation policy settings
   - variable: recommendedPolicies.allowPrivilegeEscalationPolicy.settings.allowPrivilegeEscalation
     description: >-

--- a/charts/kubewarden-defaults/templates/policyserver-default.yaml
+++ b/charts/kubewarden-defaults/templates/policyserver-default.yaml
@@ -26,6 +26,9 @@ spec:
   {{- if .Values.global.tolerations }}
   tolerations: {{ .Values.global.tolerations | toYaml | nindent 4 }}
   {{- end }}
+  {{- if .Values.global.priorityClassName }}
+  priorityClassName: {{ .Values.global.priorityClassName | toYaml | nindent 4 }}
+  {{- end }}
   {{- if .Values.policyServer.limits }}
   limits: {{ .Values.policyServer.limits | toYaml | nindent 4 }}
   {{- end }}

--- a/charts/kubewarden-defaults/tests/priorityClassName_test.yaml
+++ b/charts/kubewarden-defaults/tests/priorityClassName_test.yaml
@@ -1,0 +1,12 @@
+suite: priorityClassName configuration
+templates:
+  - policyserver-default.yaml
+tests:
+  - it: "should set the priorityClassName when .global.priorityClassName is defined"
+    set:
+      global:
+        priorityClassName: "high-priority"
+    asserts:
+      - equal:
+          path: spec.priorityClassName
+          value: "high-priority"

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -58,6 +58,7 @@ global:
   #     value: "value1"
   #     effect: "NoExecute"
   tolerations: []
+  # priorityClassName: ""
   cattle:
     systemDefaultRegistry: ghcr.io
   skipNamespaces:


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/helm-charts/issues/660
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
For both charts:
- Add new `.global.priorityClassName` value
- Add new entries questions.yml
- Add Helm unittests

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI.
questions.yaml are untested so far (albeit changes are trivial).

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
