### PR TITLE
feat: Declare support for Rancher 2.12.X

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -41,7 +41,7 @@ annotations:
   # Assume the most standard setup for your chart. These can be strings with amounts, ie 64Mi or 2Gi are both valid.
   catalog.cattle.io/requests-cpu: "250m"
   catalog.cattle.io/requests-memory: "50Mi"
-  catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.11.100-0" # Chart will only be available for users in the specified Rancher version(s). This _must_ use build metadata or it won't work correctly for future RC's.
+  catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.12.100-0" # Chart will only be available for users in the specified Rancher version(s). This _must_ use build metadata or it won't work correctly for future RC's.
   catalog.cattle.io/upstream-version: 5.2.0
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.


### PR DESCRIPTION
## Description

According to [Release Planning](https://confluence.suse.com/display/EN/Tentative+Release+Planning) Rancher 2.12.0 should be out 20 Jun, which is before our next release.

Would it make sense to add it to this release? We have rancher 2.12.0-alpha1 now.