### PR TITLE
Revert "ci: Cryptographically sign commits with updatecli (#659)"

### DIFF
--- a/updatecli/updatecli.d/major-kubewarden-update-with-crd-update.yaml
+++ b/updatecli/updatecli.d/major-kubewarden-update-with-crd-update.yaml
@@ -286,7 +286,6 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
-      commitusingapi: true # enable cryptographically signed commits
       commitmessage:
         type: "fix"
         title: "Update Kubewarden Helm charts"

--- a/updatecli/updatecli.d/major-kubewarden-update.yaml
+++ b/updatecli/updatecli.d/major-kubewarden-update.yaml
@@ -276,7 +276,6 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
-      commitusingapi: true # enable cryptographically signed commits
       commitmessage:
         type: "fix"
         title: "Update Kubewarden Helm charts"

--- a/updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml
@@ -162,7 +162,6 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
-      commitusingapi: true # enable cryptographically signed commits
       commitmessage:
         type: "fix"
         title: "Update kubewarden-controller Helm chart"

--- a/updatecli/updatecli.d/patch-kubewarden-controller.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-controller.yaml
@@ -87,7 +87,6 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
-      commitusingapi: true # enable cryptographically signed commits
       commitmessage:
         type: "fix"
         title: "Update kubewarden-controller Helm chart"

--- a/updatecli/updatecli.d/patch-kubewarden-defaults.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-defaults.yaml
@@ -73,7 +73,6 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
-      commitusingapi: true # enable cryptographically signed commits
       commitmessage:
         type: "fix"
         title: "Update kubewarden-defaults Helm chart"

--- a/updatecli/updatecli.d/prerelease-kubewarden-update-with-crd-update.yaml
+++ b/updatecli/updatecli.d/prerelease-kubewarden-update-with-crd-update.yaml
@@ -288,7 +288,6 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
-      commitusingapi: true # enable cryptographically signed commits
       commitmessage:
         type: "fix"
         title: "Update Kubewarden Helm charts"

--- a/updatecli/updatecli.d/prerelease-kubewarden-update.yaml
+++ b/updatecli/updatecli.d/prerelease-kubewarden-update.yaml
@@ -280,7 +280,6 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
-      commitusingapi: true # enable cryptographically signed commits
       commitmessage:
         type: "fix"
         title: "Update Kubewarden Helm charts"

--- a/updatecli/updatecli.d/update-deps.yaml
+++ b/updatecli/updatecli.d/update-deps.yaml
@@ -139,7 +139,6 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
-      commitusingapi: true # enable cryptographically signed commits
       commitmessage:
         type: "deps"
         title: "Update dependencies"


### PR DESCRIPTION
## Description

This reverts commit b33fc35669a7f1223a95e5a8c2d101a96a8b245f. The usage of the Github GraphQL API to create commit is causing issues in the Helm chart update scripts. Therefore, this commit revert this change until we fix that problem

I'm reverting the commit just to allow us to release the `v1.25.0` using the automation while I continue the investigation on the issue using `commitusingapi: true`. 

Related to #669 

