### PR TITLE
refactor: Use actions/github-pages to publish readme & artifacthub-repo.yml

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -44,6 +44,7 @@ jobs:
       packages: write
       contents: write
       attestations: write
+      pages: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -99,21 +100,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -ex
-          
+
           OWNER=${{ github.repository_owner }}
           REPO=helm-charts
           CONFIG_FILE=cr.yaml
           PACKAGE_PATH=.cr-release-packages
           CR_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          
+
           rm -rf ${PACKAGE_PATH}
           # Release each chart in the charts directory
           for chart in $(find charts -maxdepth 1 -mindepth 1  -type d ); do
             chart_name=$(basename $chart)
             chart_path=${PACKAGE_PATH}/${chart_name}-*.tgz
-          
+
             cr package charts/${chart_name} --config ${CONFIG_FILE} --package-path ${PACKAGE_PATH}
-          
+
             # check if the chart version is already release. If so, do nothing
             chart_version=$(helm show chart $chart_path | yq -r '.version')
             if gh --repo ${OWNER}/${REPO} release view $chart_name-$chart_version; then
@@ -121,9 +122,9 @@ jobs:
               rm $chart_path
               continue
             fi
-          
+
           done
-          
+
           # Upload the charts if the .cr-release-packages directory is not empty
           if [ "$(ls ${PACKAGE_PATH})" ]; then
             # Upload the chart to the GitHub release
@@ -149,7 +150,7 @@ jobs:
             done
           fi
 
-      - name: Prepare GH pages readme
+      - name: Prepare GH pages readme & artifacthub-repo.yml
         run: |
           mkdir -p ./to-gh-pages
           cat charts/kubewarden-controller/README.md >> charts/README.md
@@ -160,13 +161,23 @@ jobs:
           cp -f charts/README.md ./to-gh-pages/
           cp -f artifacthub-repo.yml ./to-gh-pages/
 
-      - name: Deploy readme to GH pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./to-gh-pages
-          keep_files: true
-          enable_jekyll: true
+      - name: Configure Git
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --global url."https://${GH_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
+      - name: Clone existing gh-pages branch and commit
+        run: |
+          git fetch origin gh-pages
+          git worktree add gh-pages-worktree gh-pages
+          cp -r ./to-gh-pages/* gh-pages-worktree/
+          cd gh-pages-worktree
+          git add .
+          git commit -m "Update GitHub Pages content" || echo "No changes to commit"
+          git push origin gh-pages
 
       - name: Upload images and policies file
         shell: bash


### PR DESCRIPTION

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Part of https://github.com/kubewarden/kubewarden-controller/issues/1097

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested in my fork, with,

a commit that changes the artifacthub-repo.yml:
https://github.com/viccuad/helm-charts/commit/7f4e677bff8f281c63b55527ff56c4e5c9a794af

Run:
https://github.com/viccuad/helm-charts/actions/runs/15042083010/job/42275952735

Results in correct commit to gh-pages, while keeping the history and index.yml:
https://github.com/viccuad/helm-charts/commit/c47f67cee6d88c31c72937fdb9e165b302bfb239

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

No changes needed to GH repo configuration WRT Pages.

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
