### PR TITLE
Add GitHub badge for airgap E2E test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@
 [![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)
 
 [![E2E](https://github.com/kubewarden/helm-charts/actions/workflows/e2e-tests.yml/badge.svg?event=schedule)](https://github.com/kubewarden/helm-charts/actions/workflows/e2e-tests.yml?query=event%3Aschedule)
+[![Airgap E2E Tests](https://github.com/kubewarden/helm-charts/actions/workflows/e2e-airgap.yml/badge.svg?event=schedule)](https://github.com/kubewarden/helm-charts/actions/workflows/e2e-airgap.yml?query=event%3Aschedule)
 
 This repository contains the helm charts used to deploy the Kubewarden stack.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/kubewarden-end-to-end-tests/issues/176

Add Github badge to track test status.

![image](https://github.com/user-attachments/assets/457a063a-2e41-4d18-8f7f-9f0375fb071c)

