### PR TITLE
Install bats from npm

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -120,7 +120,7 @@ jobs:
       with:
         KWCTL_VERSION: latest
 
-    - run: sudo apt install -y bats
+    - run: sudo npm install -g bats
 
     - name: "Create k3d cluster"
       run: |


### PR DESCRIPTION
Ubuntu apt package is 2 years old (1.10.0), use npm instead (1.12.0)

https://github.com/kubewarden/helm-charts/actions/runs/15499697949/job/43644628482
