### PR TITLE
fix: allow Kuberlr to download binaries.

### DIFF
--- a/charts/kubewarden-controller/templates/pre-delete-hook.yaml
+++ b/charts/kubewarden-controller/templates/pre-delete-hook.yaml
@@ -37,6 +37,9 @@ spec:
         - name: pre-delete-job
           image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
           command: ["kubectl", "delete", "--all", "policyservers.policies.kubewarden.io"]
+          env:
+            - name: KUBERLR_ALLOWDOWNLOAD
+              value: "1"
           {{- if .Values.preDeleteHook.containerSecurityContext }}
           securityContext:
             runAsUser: 1000


### PR DESCRIPTION
## Description

Updates the pre delete job to allow kuberlr download missing binaries. This avoid the errors when running the job in a kubernetes version that is bundled

Fix #708 

