### PR TITLE
fix: allow Kuberlr to download binaries #2

### DIFF
--- a/charts/kubewarden-controller/templates/post-install-hook.yaml
+++ b/charts/kubewarden-controller/templates/post-install-hook.yaml
@@ -43,6 +43,9 @@ spec:
         - name: post-install-job
           image: '{{ template "system_default_registry" . }}{{ .Values.preDeleteJob.image.repository }}:{{ .Values.preDeleteJob.image.tag }}'
           command: ["kubectl", "--namespace", "{{ .Release.Namespace }}", "rollout", "restart", "deployment", {{ include "kubewarden-controller.fullname" . }}]
+          env:
+            - name: KUBERLR_ALLOWDOWNLOAD
+              value: "1"
           {{- if .Values.preDeleteHook.containerSecurityContext }}
           securityContext:
             runAsUser: 1000


### PR DESCRIPTION
## Description

Updates the post install job to allow kuberlr download missing binaries. This avoid the errors when running the job in a kubernetes version that is bundled

Fix #708 

Follow-up PR for https://github.com/kubewarden/helm-charts/pull/709
