### PR TITLE
fix: install latest helm binary.

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -94,7 +94,13 @@ jobs:
         with:
           install_only: true
 
-      - name: Print Helm version for debugging purposes
+        # We can remove this step when this issue is fixed:
+        # https://github.com/kubewarden/helm-charts/issues/704
+      - uses: azure/setup-helm@v4.3.0
+        with:
+          version: "latest" # default is latest (stable)
+
+      - name: Show helm binary version
         shell: bash
         run: |
           helm version


### PR DESCRIPTION
## Description

Adds a temporary step in the release CI job to install the latest Helm binary fixing issues when pushing the Helm chart as OCI artifacts.

Related to https://github.com/kubewarden/helm-charts/issues/704

This is a test [run](https://github.com/jvanz/helm-charts/actions/runs/15830178890/job/44620623721) from my fork:

```console
Run curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
Helm v3.18.3 is available. Changing from version v3.18.1.
Downloading https://get.helm.sh/helm-v3.18.3-linux-amd64.tar.gz
Verifying checksum... Done.
Preparing to install helm into /usr/local/bin
helm installed into /usr/local/bin/helm
version.BuildInfo{Version:"v3.18.3", GitCommit:"6838ebcf265a3842d1433956e8a622e3290cf324", GitTreeState:"clean", GoVersion:"go1.24.4"}
helm: /usr/local/bin/helm
```

