### PR TITLE
feat: Add perm for create `subjectaccessreviews` to `kubewarden-context-watcher` role

### DIFF
--- a/charts/kubewarden-defaults/templates/policy-server-rbac.yaml
+++ b/charts/kubewarden-defaults/templates/policy-server-rbac.yaml
@@ -24,9 +24,13 @@ rules:
   - {{ .apiGroup | quote }}
   resources: {{ .resources | toJson }}
   verbs:
-  - get
-  - list
-  - watch
+  {{- if .verbs }}
+    {{- toYaml .verbs | nindent 2 }}
+  {{- else }}
+    - get
+    - list
+    - watch
+  {{- end }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -124,6 +124,8 @@ policyServer:
   permissions:
     # All permissions are cluster-wide. Even namespaced resources are
     # granted access in all namespaces at this time.
+    # By default, permissions are given for get,list,watch unless verbs
+    # are specified.
     - apiGroup: ""
       resources:
         - namespaces
@@ -132,6 +134,11 @@ policyServer:
     - apiGroup: "networking.k8s.io"
       resources:
         - ingresses
+    - apiGroup: "authorization.k8s.io"
+      resources:
+        - "subjectaccessreviews"
+      verbs:
+        - create
   env:
     - name: KUBEWARDEN_LOG_LEVEL
       value: info


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/helm-charts/issues/713


This enables the default PolicyServer to create SubjectAccessReviews. These are used for performing the new host capability `can_i`.

The change is backwards compatible with the already present values.yaml.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<details>

<summary>click here</summary>




<!-- Please provides a short description about how to test your pullrequest -->
Deploy chart from this branch, consuming also policy-server `:latest` tag:

```
helm upgrade -i --wait --namespace kubewarden --create-namespace kubewarden-defaults \
  ./charts/kubewarden-defaults --set recommendedPolicies.enabled=True \
  --set recommendedPolicies.defaultPolicyMode=monitor --set policyServer.image.tag=latest
```

Deploy context-aware-test-policy:
```
apiVersion: policies.kubewarden.io/v1
kind: ClusterAdmissionPolicy
metadata:
  annotations:
    io.kubewarden.policy.category: test
    io.kubewarden.policy.severity: info
  name: context-aware-test-policy
spec:
  backgroundAudit: true
  contextAwareResources:
  - apiVersion: v1
    kind: Namespace
  - apiVersion: apps/v1
    kind: Deployment
  mode: protect
  module: registry://ghcr.io/kubewarden/tests/context-aware-test-policy:v0.2.0
  mutating: false
  policyServer: default
  rules:
  - apiGroups:
    - apps
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    resources:
    - deployments
  settings: {}
```

Deploy a testing Deployment:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  namespace: kube-system
  labels:
    app: nginx
    app.kubernetes.io/component: "api"
    customer-id: foo
spec:
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      serviceAccountName: kubewarden
      containers:
        - name: nginx
          image: nginx:1.14.2
          ports:
            - containerPort: 80
```

<!--
```shell
cp <to_package_directory>
go test
```

</details>

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
