### PR TITLE
chore(build): Drop catalog.cattle.io/upstream-version, not needed

### DIFF
--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -42,7 +42,6 @@ annotations:
   catalog.cattle.io/requests-cpu: "250m"
   catalog.cattle.io/requests-memory: "50Mi"
   catalog.cattle.io/rancher-version: ">= 2.6.0-0 <= 2.12.100-0" # Chart will only be available for users in the specified Rancher version(s). This _must_ use build metadata or it won't work correctly for future RC's.
-  catalog.cattle.io/upstream-version: 5.4.0
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -33,7 +33,6 @@ annotations:
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
   catalog.cattle.io/hidden: "true" # Hide specific charts. Only use on CRD charts.
-  catalog.cattle.io/upstream-version: 1.18.0
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -35,7 +35,6 @@ annotations:
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
   catalog.cattle.io/hidden: "true" # Hide specific charts. Only use on CRD charts.
-  catalog.cattle.io/upstream-version: 3.4.0
   catalog.cattle.io/auto-install: kubewarden-crds=1.18.0
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.

--- a/updatecli/updatecli.d/major-kubewarden-update-with-crd-update.yaml
+++ b/updatecli/updatecli.d/major-kubewarden-update-with-crd-update.yaml
@@ -130,16 +130,6 @@ targets:
       key: 'annotations.catalog\.cattle\.io/auto-install'
       value: 'kubewarden-crds={{ source "crdChartVersion" }}'
 
-  updateCRDUpstreamVersionAnnotation:
-    name: "Update kubewarden-crds upstream-version annotation"
-    kind: yaml
-    sourceid: crdChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-crds/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
-      value: '{{ source "crdChartVersion" }}'
-
   updateCRDChartVersion:
     name: "Update kubewarden-crds version"
     kind: yaml
@@ -189,15 +179,6 @@ targets:
       key: "appVersion"
       value: "{{ requiredEnv .releaseVersion }}"
 
-  defaultChartVersionUpdate2:
-    name: Bump defaults chart version in annotations
-    kind: yaml
-    sourceid: defaultChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
-
   updateDefautlsAutoInstallAnnotation:
     name: "Update kubewarden-defautls auto-install annotation"
     kind: yaml
@@ -246,15 +227,6 @@ targets:
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "version"
-
-  controllerChartVersionUpdate2:
-    name: Bump controller chart version in annotations
-    kind: yaml
-    sourceid: controllerChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
 
 actions:
   createUpdatePR:

--- a/updatecli/updatecli.d/major-kubewarden-update.yaml
+++ b/updatecli/updatecli.d/major-kubewarden-update.yaml
@@ -122,16 +122,6 @@ targets:
       key: "$.annotations.'catalog.cattle.io/auto-install'"
       value: 'kubewarden-crds={{ source "crdChartVersion" }}'
 
-  updateCRDUpstreamVersionAnnotation:
-    name: "Update kubewarden-crds upstream-version annotation"
-    kind: yaml
-    sourceid: crdChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-crds/Chart.yaml"
-      key: "$.annotations.'catalog.cattle.io/upstream-version'"
-      value: '{{ source "crdChartVersion" }}'
-
   updateCRDChartVersion:
     name: "Update kubewarden-crds version"
     kind: yaml
@@ -169,15 +159,6 @@ targets:
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
       key: "$.version"
-
-  defaultChartVersionUpdate2:
-    name: Bump defaults chart version in annotations
-    kind: yaml
-    sourceid: defaultChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: "$.annotations.'catalog.cattle.io/upstream-version'"
 
   updateDefautlsAutoInstallAnnotation:
     name: "Update kubewarden-defautls auto-install annotation"
@@ -237,15 +218,6 @@ targets:
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "$.version"
-
-  controllerChartVersionUpdate2:
-    name: Bump controller chart version in annotations
-    kind: yaml
-    sourceid: controllerChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: "$.annotations.'catalog.cattle.io/upstream-version'"
 
 actions:
   createUpdatePR:

--- a/updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-controller-with-crds-update.yaml
@@ -71,17 +71,6 @@ targets:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "version"
 
-  chartPatchVersionUpdate2:
-    name: Bump chart patch version in annotations
-    kind: yaml
-    sourceid: controllerChart
-    scmid: "default"
-    transformers:
-      - semverinc: "patch"
-    spec:
-      file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
-
   updateControllerAutoInstallAnnotation:
     name: "Update kubewarden-controller auto-install annotation"
     kind: yaml
@@ -112,16 +101,6 @@ targets:
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
       key: "version"
-
-  updateCRDUpstreamVersionAnnotation:
-    name: "Update kubewarden-crds upstream-version annotation"
-    kind: yaml
-    sourceid: crdChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-crds/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
-      value: '{{ source "crdChartVersion" }}'
 
   updateCRDChartPatchVersion:
     name: "Update kubewarden-crds version"

--- a/updatecli/updatecli.d/patch-kubewarden-controller.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-controller.yaml
@@ -47,16 +47,6 @@ targets:
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "version"
-  chartPatchVersionUpdate2:
-    name: Bump chart patch version in annotations
-    kind: yaml
-    sourceid: controllerChart
-    scmid: "default"
-    transformers:
-      - semverinc: "patch"
-    spec:
-      file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
 
 actions:
   createUpdatePR:

--- a/updatecli/updatecli.d/patch-kubewarden-defaults.yaml
+++ b/updatecli/updatecli.d/patch-kubewarden-defaults.yaml
@@ -33,16 +33,6 @@ targets:
     spec:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
       key: "version"
-  chartPatchVersionUpdate2:
-    name: Bump chart patch version in annotations
-    kind: yaml
-    sourceid: chart
-    scmid: "default"
-    transformers:
-      - semverinc: "patch"
-    spec:
-      file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
 
 actions:
   createUpdatePR:

--- a/updatecli/updatecli.d/prerelease-kubewarden-update-with-crd-update.yaml
+++ b/updatecli/updatecli.d/prerelease-kubewarden-update-with-crd-update.yaml
@@ -133,16 +133,6 @@ targets:
       key: 'annotations.catalog\.cattle\.io/auto-install'
       value: 'kubewarden-crds={{ source "crdChartVersion" }}'
 
-  updateCRDUpstreamVersionAnnotation:
-    name: "Update kubewarden-crds upstream-version annotation"
-    kind: yaml
-    sourceid: crdChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-crds/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
-      value: '{{ source "crdChartVersion" }}'
-
   updateCRDChartVersion:
     name: "Update kubewarden-crds version"
     kind: yaml
@@ -192,15 +182,6 @@ targets:
       key: "appVersion"
       value: "{{ requiredEnv .releaseVersion }}"
 
-  defaultChartVersionUpdate2:
-    name: Bump defaults chart version in annotations
-    kind: yaml
-    sourceid: defaultChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
-
   updateDefautlsAutoInstallAnnotation:
     name: "Update kubewarden-defautls auto-install annotation"
     kind: yaml
@@ -249,15 +230,6 @@ targets:
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "version"
-
-  controllerChartVersionUpdate2:
-    name: Bump controller chart version in annotations
-    kind: yaml
-    sourceid: controllerChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: 'annotations.catalog\.cattle\.io/upstream-version'
 
 actions:
   createUpdatePR:

--- a/updatecli/updatecli.d/prerelease-kubewarden-update.yaml
+++ b/updatecli/updatecli.d/prerelease-kubewarden-update.yaml
@@ -125,16 +125,6 @@ targets:
       key: "$.annotations.'catalog.cattle.io/auto-install'"
       value: 'kubewarden-crds={{ source "crdChartVersion" }}'
 
-  updateCRDUpstreamVersionAnnotation:
-    name: "Update kubewarden-crds upstream-version annotation"
-    kind: yaml
-    sourceid: crdChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-crds/Chart.yaml"
-      key: "$.annotations.'catalog.cattle.io/upstream-version'"
-      value: '{{ source "crdChartVersion" }}'
-
   updateCRDChartVersion:
     name: "Update kubewarden-crds version"
     kind: yaml
@@ -184,15 +174,6 @@ targets:
       file: "file://charts/kubewarden-defaults/Chart.yaml"
       key: "$.version"
 
-  defaultChartVersionUpdate2:
-    name: Bump defaults chart version in annotations
-    kind: yaml
-    sourceid: defaultChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-defaults/Chart.yaml"
-      key: "$.annotations.'catalog.cattle.io/upstream-version'"
-
   defaultChartAppVersionUpdate:
     name: Bump defaults chart app version
     kind: yaml
@@ -241,15 +222,6 @@ targets:
     spec:
       file: "file://charts/kubewarden-controller/Chart.yaml"
       key: "$.version"
-
-  controllerChartVersionUpdate2:
-    name: Bump controller chart version in annotations
-    kind: yaml
-    sourceid: controllerChartVersion
-    scmid: "default"
-    spec:
-      file: "file://charts/kubewarden-controller/Chart.yaml"
-      key: "$.annotations.'catalog.cattle.io/upstream-version'"
 
 actions:
   createUpdatePR:


### PR DESCRIPTION


## Description

This rancher annotation is only used to disallow accidental downgrades, and seems to be in disuse. Other charts are already not honoring.

Removing it as deprecated.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
