### PR TITLE
Update tests to target k8s 1.27

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,8 +13,6 @@ on:
         options:
           [
             "k3d",
-            "1.25",
-            "1.26",
             "1.27",
             "1.28",
             "1.29",
@@ -22,6 +20,7 @@ on:
             "1.31",
             "1.32",
             "1.33",
+            "1.34",
           ]
         default: "k3d"
       ARCH:
@@ -102,17 +101,17 @@ jobs:
           (github.event_name == 'schedule') && fromJSON('["local", "next"]') ||
           (github.event_name == 'pull_request') && fromJSON('["local"]') ||
           fromJSON(format('["{0}"]', inputs.version || 'local')) }}
-        k3s: ${{ (github.event_name == 'workflow_run') && fromJSON('["k3d", "1.25"]') || fromJSON(format('["{0}"]', inputs.K3S_VERSION || 'k3d' )) }}
+        k3s: ${{ (github.event_name == 'workflow_run') && fromJSON('["k3d", "1.27"]') || fromJSON(format('["{0}"]', inputs.K3S_VERSION || 'k3d' )) }}
         arch: ${{ (github.event_name == 'workflow_run') && fromJSON('["x86", "arm64"]') || fromJSON(format('["{0}"]', inputs.ARCH || 'x86')) }}
         exclude:
-          - k3s: ${{ (github.event_name == 'workflow_run') && '1.25' }}
+          - k3s: ${{ (github.event_name == 'workflow_run') && '1.27' }}
             mode: upgrade
           - version: ${{ (github.event_name == 'schedule') && 'next' }}
             mode: upgrade
           - arch: ${{ (github.event_name == 'workflow_run') && 'arm64' }}
             mode: upgrade
           - arch: ${{ (github.event_name == 'workflow_run') && 'arm64' }}
-            version: "1.25"
+            version: "1.27"
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
## Description

Run release tests on k8s 1.27 instead of 1.25.