### PR TITLE
Trigger release tests only for specific jobs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,5 +1,7 @@
 name: End-to-end tests
 
+run-name: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.display_title || '' }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -86,7 +88,7 @@ jobs:
     # Run schedule workflows only on original repo, not forks
     if:
       (github.event_name != 'schedule' || github.repository_owner == 'kubewarden') &&
-      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+      (github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.display_title, 'Helm chart') ))
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Currently we trigger release tests for every merged pull request.
This change skips release tests unless PR is named `Helm chart...`, we use `Helm chart (major|minor|patch) release` pattern.

Test run: https://github.com/kravciak/helm-charts/actions/runs/16776664194