### PR TITLE
Dynamically generate update-deps updatecli pipeline and update Hauler manifest

### DIFF
--- a/updatecli/updatecli.d/update-deps.yaml
+++ b/updatecli/updatecli.d/update-deps.yaml
@@ -1,102 +1,25 @@
 name: Update charts with new policy versions, kubectl image
 
 sources:
-  kuberlrKubectlImageTag:
+  # {{ range $oci := .ociArtifacts}}
+  "source/{{ $oci.image }}":
     kind: dockerimage
     spec:
-      image: ghcr.io/rancher/kuberlr-kubectl
+      image: "{{ $oci.image }}"
       versionfilter:
         kind: semver
-  allowPrivilegeEscalationPolicyTag:
-    kind: dockerimage
-    spec:
-      image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp
-      versionfilter:
-        kind: semver
-  hostNamespacePolicyTag:
-    kind: dockerimage
-    spec:
-      image: ghcr.io/kubewarden/policies/host-namespaces-psp
-      versionfilter:
-        kind: semver
-  podPrivilegedPolicyTag:
-    kind: dockerimage
-    spec:
-      image: ghcr.io/kubewarden/policies/pod-privileged
-      versionfilter:
-        kind: semver
-  userGroupPolicyTag:
-    kind: dockerimage
-    spec:
-      image: ghcr.io/kubewarden/policies/user-group-psp
-      versionfilter:
-        kind: semver
-  hostPathsPolicyTag:
-    kind: dockerimage
-    spec:
-      image: ghcr.io/kubewarden/policies/hostpaths-psp
-      versionfilter:
-        kind: semver
-  capabilitiesPolicyTag:
-    kind: dockerimage
-    spec:
-      image: ghcr.io/kubewarden/policies/capabilities-psp
-      versionfilter:
-        kind: semver
+  # {{ end }}
 
 targets:
-  updatekubectlTag:
-    name: Update kuberlr-kubectl image tag
+  # {{ range $oci := .ociArtifacts}}
+  "target/{{ $oci.image }}":
+    name: "Update {{ $oci.image }} image tag"
     kind: yaml
-    sourceid: kuberlrKubectlImageTag
+    sourceid: "source/{{ $oci.image }}"
     scmid: "default"
     spec:
-      file: "charts/kubewarden-controller/values.yaml"
-      key: "$.preDeleteJob.image.tag"
-  updateAllowPrivilegeEscalationPolicyTag:
-    name: Update allow-privilege-escalation-psp tag
-    kind: yaml
-    sourceid: allowPrivilegeEscalationPolicyTag
-    scmid: "default"
-    spec:
-      file: "charts/kubewarden-defaults/values.yaml"
-      key: "$.recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag"
-  updateHostNamespacePolicyTag:
-    name: Update host-namespaces-psp tag
-    kind: yaml
-    sourceid: hostNamespacePolicyTag
-    scmid: "default"
-    spec:
-      file: "charts/kubewarden-defaults/values.yaml"
-      key: "$.recommendedPolicies.hostNamespacePolicy.module.tag"
-  updatePodPrivilegedPolicyTag:
-    name: Update pod-privileged tag
-    kind: yaml
-    sourceid: podPrivilegedPolicyTag
-    scmid: "default"
-    spec:
-      file: "charts/kubewarden-defaults/values.yaml"
-      key: "$.recommendedPolicies.podPrivilegedPolicy.module.tag"
-  updateUserGroupPolicyTag:
-    name: Update user-group-psp tag
-    kind: yaml
-    sourceid: userGroupPolicyTag
-    scmid: "default"
-    spec:
-      file: "charts/kubewarden-defaults/values.yaml"
-      key: "$.recommendedPolicies.userGroupPolicy.module.tag"
-  updateHostPathsPolicyTag:
-    name: Update hostpaths-psp tag
-    kind: yaml
-    sourceid: hostPathsPolicyTag
-    scmid: "default"
-    spec:
-      file: "charts/kubewarden-defaults/values.yaml"
-      key: "$.recommendedPolicies.hostPathsPolicy.module.tag"
-  updateCapabilitiesPolicyTag:
-    name: Update capabilities-psp tag
-    kind: yaml
-    sourceid: capabilitiesPolicyTag
+      file: "{{ $oci.file }}"
+      key: "{{ $oci.key }}"
     scmid: "default"
     spec:
       file: "charts/kubewarden-defaults/values.yaml"

--- a/updatecli/updatecli.d/update-deps.yaml
+++ b/updatecli/updatecli.d/update-deps.yaml
@@ -20,10 +20,16 @@ targets:
     spec:
       file: "{{ $oci.file }}"
       key: "{{ $oci.key }}"
+  "targetHauler/{{ $oci.image }}":
+    name: "Update {{ $oci.image }} image in Hauler manifest"
+    kind: file
+    sourceid: "source/{{ $oci.image }}"
     scmid: "default"
     spec:
-      file: "charts/kubewarden-defaults/values.yaml"
-      key: "$.recommendedPolicies.capabilitiesPolicy.module.tag"
+      file: "charts/hauler_manifest.yaml"
+      matchpattern: "(.*)- ?name: ?{{ $oci.image }}:(v.+) ?(.*)"
+      replacepattern: '$1- name: {{ $oci.image }}:{{ printf "source/%s" $oci.image | source }}'
+  # {{ end }}
 
 actions:
   openUpdatePR:

--- a/updatecli/updatecli.d/update-deps.yaml
+++ b/updatecli/updatecli.d/update-deps.yaml
@@ -1,4 +1,17 @@
-name: Update charts with new policy versions, kubectl image
+name: Update charts and Hauler manifest with new policies, policy-reporter and kubectl versions
+
+# Using autodiscovery to update the policy-reporter chart dependency
+autodiscovery:
+  scmid: default
+  crawlers:
+    helm:
+      versionfilter:
+        kind: semver
+        # It's not possible to use autodiscovery to update container images because
+        # we do not follow the expected pattern in the value due the feature to
+        # define a different default registry
+      ignorecontainer: true
+      versionincrement: "none"
 
 sources:
   # {{ range $oci := .ociArtifacts}}
@@ -8,7 +21,27 @@ sources:
       image: "{{ $oci.image }}"
       versionfilter:
         kind: semver
+        # {{ if $oci.strict }}
+        strict: true
+        # {{ end }}
   # {{ end }}
+  policyReporterHelmChartLatestVersion:
+    kind: "helmchart"
+    spec:
+      url: "https://kyverno.github.io/policy-reporter"
+      name: policy-reporter
+
+conditions:
+  # Adding this condition just to ensure that the policy-reporter chart is in
+  # the expected position. Hopefully, we could find a better way to do that in
+  # the target bellow. See why this is necessary in the target comment
+  positionPolicyReporterChartHaulerManifest:
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "charts/hauler_manifest.yaml"
+      key: "$.spec.charts[3].name"
+      value: "policy-reporter"
 
 targets:
   # {{ range $oci := .ociArtifacts}}
@@ -17,6 +50,8 @@ targets:
     kind: yaml
     sourceid: "source/{{ $oci.image }}"
     scmid: "default"
+    dependson:
+      - '{{ printf "source#source/%s" $oci.image }}'
     spec:
       file: "{{ $oci.file }}"
       key: "{{ $oci.key }}"
@@ -25,11 +60,26 @@ targets:
     kind: file
     sourceid: "source/{{ $oci.image }}"
     scmid: "default"
+    dependson:
+      - '{{ printf "source#source/%s" $oci.image }}'
     spec:
       file: "charts/hauler_manifest.yaml"
-      matchpattern: "(.*)- ?name: ?{{ $oci.image }}:(v.+) ?(.*)"
+      matchpattern: "(.*)- ?name: ?{{ $oci.image }}:(v?.+) ?(.*)"
       replacepattern: '$1- name: {{ $oci.image }}:{{ printf "source/%s" $oci.image | source }}'
   # {{ end }}
+  targetHauler/policy-reporter-helm-chart:
+    name: "Update policy-reporter Helm chart version in Hauler manifest"
+    kind: yaml
+    sourceid: "policyReporterHelmChartLatestVersion"
+    scmid: "default"
+    dependson:
+      - "condition#positionPolicyReporterChartHaulerManifest"
+    spec:
+      file: "charts/hauler_manifest.yaml"
+      # Yamlpath to filter the helm chart by name did not work. That's why we
+      # have the condition to ensure the script is not updating the wrong helm
+      # chart
+      key: "$.spec.charts[3].version"
 
 actions:
   openUpdatePR:

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -12,6 +12,7 @@ ociArtifacts:
   - image: ghcr.io/rancher/kuberlr-kubectl
     file: "charts/kubewarden-controller/values.yaml"
     key: "$.preDeleteJob.image.tag"
+  # Policies
   - image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp
     file: "charts/kubewarden-defaults/values.yaml"
     key: "$.recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag"
@@ -30,3 +31,12 @@ ociArtifacts:
   - image: ghcr.io/kubewarden/policies/capabilities-psp
     file: "charts/kubewarden-defaults/values.yaml"
     key: "$.recommendedPolicies.capabilitiesPolicy.module.tag"
+  # Policy reporter container images
+  - image: ghcr.io/kyverno/policy-reporter
+    file: "charts/kubewarden-controller/values.yaml"
+    key: "$.policy-reporter.image.tag"
+    strict: true
+  - image: ghcr.io/kyverno/policy-reporter-ui
+    file: "charts/kubewarden-controller/values.yaml"
+    key: "$.policy-reporter.ui.image.tag"
+    strict: true

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -8,3 +8,25 @@ github:
   author: "Kubewarden bot"
   email: "cncf-kubewarden-maintainers@lists.cncf.io"
   user: "UPDATECLI_GITHUB_OWNER"
+ociArtifacts:
+  - image: ghcr.io/rancher/kuberlr-kubectl
+    file: "charts/kubewarden-controller/values.yaml"
+    key: "$.preDeleteJob.image.tag"
+  - image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag"
+  - image: ghcr.io/kubewarden/policies/host-namespaces-psp
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.hostNamespacePolicy.module.tag"
+  - image: ghcr.io/kubewarden/policies/pod-privileged
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.podPrivilegedPolicy.module.tag"
+  - image: ghcr.io/kubewarden/policies/user-group-psp
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.userGroupPolicy.module.tag"
+  - image: ghcr.io/kubewarden/policies/hostpaths-psp
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.hostPathsPolicy.module.tag"
+  - image: ghcr.io/kubewarden/policies/capabilities-psp
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.recommendedPolicies.capabilitiesPolicy.module.tag"


### PR DESCRIPTION
## Description

Updates the updatecli pipeline to generate the sources and targets to updates OCI artifact versions based on the configuration values. Therefore, when a new dependency is added, only the values files needs to be updated.

Also,  updates the updatecli script used to update the policies and kuberlr version to also update the version in the Hauler manifest.

Part of https://github.com/kubewarden/helm-charts/issues/736

> [!WARNING]
> This PR is not addressing all the acceptance criteria from the https://github.com/kubewarden/helm-charts/issues/736. It's the first step with a refactoring to make the remaining changes simpler. ;) 

## Test


```shell
export UPDATECLI_GITHUB_OWNER=<your user>
export UPDATECLI_GITHUB_TOKEN=<your token>
updatecli apply --config updatecli/updatecli.d/update-deps.yaml --values updatecli/values.yaml
```
