### PR TITLE
fix(dep): update Kubewarden container images steps.

### DIFF
--- a/updatecli/update-deps-values.yaml
+++ b/updatecli/update-deps-values.yaml
@@ -1,3 +1,20 @@
 pipelineid: "update_helm_chart_dependencies"
 pr:
   title: "Helm chart dependencies updates"
+
+kubewardenContainerImage:
+  - name: "controller"
+    file: "charts/kubewarden-controller/values.yaml"
+    key: "$.image.tag"
+    image: "ghcr.io/kubewarden/kubewarden-controller"
+    workflowUrl: "https://github.com/kubewarden/kubewarden-controller/.github/workflows/release.yml@refs/tags"
+  - name: "auditScanner"
+    file: "charts/kubewarden-controller/values.yaml"
+    key: "$.auditScanner.image.tag"
+    image: "ghcr.io/kubewarden/audit-scanner"
+    workflowUrl: "https://github.com/kubewarden/audit-scanner/.github/workflows/release.yml@refs/tags"
+  - name: "policyServer"
+    file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.policyServer.image.tag"
+    image: "ghcr.io/kubewarden/policy-server"
+    workflowUrl: "https://github.com/kubewarden/policy-server/.github/workflows/release.yml@refs/tags"

--- a/updatecli/updatecli.d/update-chart-deps.yaml
+++ b/updatecli/updatecli.d/update-chart-deps.yaml
@@ -19,6 +19,9 @@ autodiscovery:
 
 sources:
   # {{ range $oci := .ociArtifacts}}
+  # Kubewarden container image should now use the version from the registry.
+  # Let keep using the version defined in the release process.
+  # {{ if not $oci.skipVersionFromRegistry }}
   "source/{{ $oci.image }}":
     kind: dockerimage
     spec:
@@ -29,9 +32,11 @@ sources:
         strict: true
         # {{ end }}
   # {{ end }}
+  # {{ end }}
 
 targets:
   # {{ range $oci := .ociArtifacts}}
+  # {{ if not $oci.skipVersionFromRegistry }}
   "target/{{ $oci.image }}":
     name: "Update {{ $oci.image }} image tag"
     kind: yaml
@@ -42,6 +47,7 @@ targets:
     spec:
       file: "{{ $oci.file }}"
       key: "{{ $oci.key }}"
+  # {{ end }}
   # {{ end }}
 
 actions:

--- a/updatecli/updatecli.d/update-hauler-manifest.yaml
+++ b/updatecli/updatecli.d/update-hauler-manifest.yaml
@@ -69,6 +69,19 @@ targets:
       file: "charts/hauler_manifest.yaml"
       matchpattern: "(.*)- ?name: ?{{ $oci.image }}:(v?.+) ?(.*)"
       replacepattern: '$1- name: {{ $oci.image }}:{{ printf "source/%sVersion" $oci.image | source }}'
+  # {{ if $oci.workflowUrl }}
+  "target/{{ $oci.image }}IdentityRegex":
+    name: "Update {{ $oci.image }} image identity regex in Hauler manifest"
+    kind: file
+    sourceid: "source/{{ $oci.image }}Version"
+    dependson:
+      - '{{ printf "source#source/%sVersion" $oci.image }}'
+    scmid: "default"
+    spec:
+      file: "charts/hauler_manifest.yaml"
+      matchpattern: "(.*)? certificate-identity-regexp: ?{{ $oci.workflowUrl }}/(v?.+) ?(.*)"
+      replacepattern: '$1 certificate-identity-regexp: {{ $oci.workflowUrl }}/{{ printf "source/%sVersion" $oci.image | source }}'
+  # {{ end }}
   # {{ end }}
   # {{ range $i, $chart := .helmCharts}}
   "target/{{ $chart.name}}Chart":

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -12,6 +12,30 @@ github:
 # The ociArtifacts list all the container images and policies that needs
 # to be updated in the manifest
 ociArtifacts:
+  # Kubewarden container images
+  #
+  # The workflowUrl field defined in the Kubewarden
+  # container images is the url used to validate the identity with cosign
+  #
+  # The skipVersionFromRegistry field defined in the Kubewarden images is a
+  # flag to skip update of the images version in the Helm chart with the
+  # version in the registry. These container image should use the container
+  # image defined in the release process
+  - file: "charts/kubewarden-controller/values.yaml"
+    key: "$.image.tag"
+    image: "ghcr.io/kubewarden/kubewarden-controller"
+    workflowUrl: "https://github.com/kubewarden/kubewarden-controller/.github/workflows/release.yml@refs/tags"
+    skipVersionFromRegistry: true
+  - file: "charts/kubewarden-controller/values.yaml"
+    key: "$.auditScanner.image.tag"
+    image: "ghcr.io/kubewarden/audit-scanner"
+    workflowUrl: "https://github.com/kubewarden/audit-scanner/.github/workflows/release.yml@refs/tags"
+    skipVersionFromRegistry: true
+  - file: "charts/kubewarden-defaults/values.yaml"
+    key: "$.policyServer.image.tag"
+    image: "ghcr.io/kubewarden/policy-server"
+    workflowUrl: "https://github.com/kubewarden/policy-server/.github/workflows/release.yml@refs/tags"
+    skipVersionFromRegistry: true
   # Policies
   - image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp
     file: "charts/kubewarden-defaults/values.yaml"


### PR DESCRIPTION
## Description

Updates the updatecli used to keep the Hauler manifest to have all steps to update the Kubewarden container image with the values from the Helm charts.

In the recent change on automation we forgot to add the Kubewarden container image in the list of the image to be updated in the Hauler manifest. :facepalm: 

This is a [PR](https://github.com/jvanz/helm-charts/pull/159) generated with this changes ran on Github CI. 

## Test

```shell
UPDATECLI_GITHUB_OWNER="<your github user>" UPDATECLI_GITHUB_TOKEN="<your github token>" updatecli compose apply --file ./updatecli/update-deps.yaml
```