### PR TITLE
Consume `policy-server:v1.28.1`, Patch release of `kubewarden-defaults` Helm chart

### DIFF
--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -22,9 +22,9 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.6.0
+version: 3.6.1
 # This is the version of Kubewarden stack
-appVersion: v1.28.0
+appVersion: v1.28.1
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -116,7 +116,7 @@ policyServer:
   image:
     # The registry is defined in the global.cattle.systemDefaultRegistry value
     repository: "kubewarden/policy-server"
-    tag: v1.28.0
+    tag: v1.28.1
   serviceAccountName: policy-server
   # verificationConfig: your_configmap
   # Configmap containing a Sigstore verification configuration under a key


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Consumes policy-server:v1.28.1, which contains a fix for [CVE-2025-58160](https://www.wiz.io/vulnerability-database/cve/cve-2025-58160)  for the dependency `tracing-subscriber`, for which we are not particularly affected. Yet this makes image scanners happy.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
