### PR TITLE
fix(ci): replace autodiscovery by source/target steps.

### DIFF
--- a/updatecli/updatecli.d/update-chart-deps.yaml
+++ b/updatecli/updatecli.d/update-chart-deps.yaml
@@ -4,19 +4,6 @@ name: Update charts with new policies, policy-reporter and kubectl versions
 pipelineid: "{{ .pipelineid }}"
 # {{ end }}
 
-# Using autodiscovery to update the policy-reporter chart dependency
-autodiscovery:
-  scmid: default
-  crawlers:
-    helm:
-      versionfilter:
-        kind: semver
-        # It's not possible to use autodiscovery to update container images because
-        # we do not follow the expected pattern in the value due the feature to
-        # define a different default registry
-      ignorecontainer: true
-      versionincrement: "none"
-
 sources:
   # {{ range $oci := .ociArtifacts}}
   # Kubewarden container image should now use the version from the registry.
@@ -33,6 +20,15 @@ sources:
         # {{ end }}
   # {{ end }}
   # {{ end }}
+  # {{ range $chart := .helmCharts}}
+  # {{ if $chart.repository }}
+  "source/{{ $chart.name }}Chart":
+    kind: helmchart
+    spec:
+      url: "{{ $chart.repository }}"
+      name: "{{ $chart.name }}"
+  # {{ end }}
+  # {{ end }}
 
 targets:
   # {{ range $oci := .ociArtifacts}}
@@ -47,6 +43,20 @@ targets:
     spec:
       file: "{{ $oci.file }}"
       key: "{{ $oci.key }}"
+  # {{ end }}
+  # {{ end }}
+  # {{ range $chart := .helmCharts}}
+  # {{ if $chart.repository }}
+  "target/{{ $chart.name }}Chart":
+    name: "Update {{ $chart.name }} dependency helm chart"
+    kind: yaml
+    sourceid: "source/{{ $chart.name }}Chart"
+    scmid: "default"
+    dependson:
+      - '{{ printf "source#source/%sChart" $chart.name }}'
+    spec:
+      file: "{{ $chart.file }}"
+      key: "{{ $chart.versionKey }}"
   # {{ end }}
   # {{ end }}
 

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -83,3 +83,4 @@ helmCharts:
   - name: policy-reporter
     file: "charts/kubewarden-controller/Chart.yaml"
     versionKey: "$.dependencies[0].version"
+    repository: https://kyverno.github.io/policy-reporter


### PR DESCRIPTION
## Description

Updates the updatecli script used to update dependencies replacing the autodiscovery by source/target steps. Otherwise, the Hauler manifest will be out of date due the order of execution of the steps.

## Test

Run CI to update dependencies.

The [PR](https://github.com/jvanz/helm-charts/pull/170) is generated by CI with this changes
