### PR TITLE
Add new option to backup user custom resources

### DIFF
--- a/.github/workflows/e2e-backup-restore.yml
+++ b/.github/workflows/e2e-backup-restore.yml
@@ -101,8 +101,9 @@ jobs:
           # WAITING ON MERGING PR (https://github.com/rancher/backup-restore-operator/pull/789)
           cd ${GITHUB_WORKSPACE}/backup-restore-operator
           helm install --wait  --create-namespace -n cattle-resources-system  rancher-backup-crd ./charts/rancher-backup-crd
-          sed -i 's/%TAG%/v7.0.1/g' ./charts/rancher-backup/values.yaml
-          helm install --wait -n cattle-resources-system rancher-backup ./charts/rancher-backup --set persistence.enabled=true --set persistence.storageClass=local-path
+          # ADD SOMETHING TO GET THE VERSION DYNAMICALLY
+          sed -i 's/%TAG%/v8.1.0/g' ./charts/rancher-backup/values.yaml
+          helm install --wait -n cattle-resources-system rancher-backup ./charts/rancher-backup --set persistence.enabled=true --set persistence.storageClass=local-path --set optionalResources.kubewardenUserCRs.enabled=true
 
 
       - name: Extract component versions/informations


### PR DESCRIPTION
## Description

- Bump backup-restore operator version (will automate this in next PR)
- Add new option `optionalResources.kubewardenUserCRs.enabled=true` to backup user custom resources

**Reminder:** helm installation will be removed of the github action in favor of our e2e golang code, because we still have to use Victor's fork.

## Verification run
[Backup-restore test](https://github.com/kubewarden/helm-charts/actions/runs/17977914555) ✅ 
