### PR TITLE
ci: Disable renovatebot for policy-reporter-ui

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,10 @@
   ],
   "packageRules": [
     {
-      "allowedVersions": "!/1.15.1$/",
       "matchPackageNames": [
         "/.*kyverno/policy-reporter-ui/"
-      ]
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
It conflicts with the updatecli bumps, plus the bump needs to be done in lockstep with the policy-reporter Helm chart.

See https://github.com/kubewarden/helm-charts/pull/795#issuecomment-3363122917
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
