### PR TITLE
feat(audit-scanner): allow storing results with OpenReports.

### DIFF
--- a/charts/kubewarden-controller/templates/_helpers.tpl
+++ b/charts/kubewarden-controller/templates/_helpers.tpl
@@ -158,4 +158,8 @@ Create the name of the service account to use for kubewarden-controller
 - {{ printf "-i" }}
 - {{ printf "%s" . }}
 {{- end -}}
+{{- if .Values.auditScanner.reportCrdsKind }}
+- --report-kind
+- {{ .Values.auditScanner.reportCrdsKind }}
+{{- end -}}
 {{- end -}}

--- a/charts/kubewarden-controller/tests/audit_scanner_test.yaml
+++ b/charts/kubewarden-controller/tests/audit_scanner_test.yaml
@@ -1,0 +1,27 @@
+suite: Audit scanner configuration
+templates:
+  - audit-scanner.yaml
+tests:
+  - it: "should set report-kind properly when value is defined"
+    set:
+      auditScanner:
+        reportCrdsKind: "openreports"
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          content:
+            --report-kind
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          content:
+            "openreports"
+  - it: "should not set report-kind when no value is defined"
+    asserts:
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          content:
+            --report-kind
+      - notContains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          content:
+            "openreports"

--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -232,6 +232,21 @@ resources:
       cpu: 250m
       memory: 70Mi
   auditScanner:
+    # Audit scanner allow users to use Kubernetes policy working group
+    # PolicyReports CRDs or OpenReports CRDs to store the results of the
+    # audits. Therefore, user can choose between: openreports or policyreport.
+    # If not defined, the audit scanner default value is used. Which is
+    # "openreports"
+    #
+    # The CRDs used to store the audit scanner results must be installed in the
+    # cluster. You can install both of them enabling the right flags in the
+    # kubewarden-crds installation. If you want to use the PolicyReports CRDs,
+    # enable the installPolicyReportCRDs flag. If you want to use the
+    # OpenReports CRDs, enable the installOpenReportCRDs flag.
+    #
+    # Rancher users must use "policyreport" as the reportCrdsKind, as Rancher
+    # UI does not support the OpenReports CRDs yet.
+    reportCrdsKind: "policyreport"
     limits:
       cpu: 500m
       memory: 1Gi


### PR DESCRIPTION
## Description

Updates the audit scanner job allow users to define which CRDs they want to use to store the audit scan results. The available options are "openrepots" and "policyreport".

"openreports" option configure the audit scanner to store the results in the OpenReports CRDs. And, "policyreport" configures the scanner to store the results in the, now deprecated, Kubernetes policy working group policy reports CRDs.


Fix https://github.com/kubewarden/audit-scanner/issues/592


## Test

```shell
make test
```

