### PR TITLE
chore(updatecli): update OpenReports CRDs Helm chart.

### DIFF
--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -68,3 +68,6 @@ spec:
     - name: policy-reporter
       version: 3.5.0
       repoURL: https://kyverno.github.io/policy-reporter
+    - name: openreports
+      version: 0.2.1
+      repoURL: https://openreports.github.io/reports-api

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -84,3 +84,7 @@ helmCharts:
     file: "charts/kubewarden-controller/Chart.yaml"
     versionKey: "$.dependencies[0].version"
     repository: https://kyverno.github.io/policy-reporter
+  - name: openreports
+    file: "charts/kubewarden-crds/Chart.yaml"
+    versionKey: "$.dependencies[0].version"
+    repository: https://openreports.github.io/reports-api


### PR DESCRIPTION
## Description

Updates the updatecli values to include the OpenReports Helm chart dependency in the dependencies that should be updated. Furthermore, added the OpenReports Helm chart in the Hauler manifest.

Fix https://github.com/kubewarden/audit-scanner/issues/593

