### PR TITLE
Add test summary

### DIFF
--- a/.github/actions/logs-and-summary/action.yaml
+++ b/.github/actions/logs-and-summary/action.yaml
@@ -1,0 +1,60 @@
+# This action is a reusable one called by local workflows
+name: logs-and-summary
+description: 'Add logs and summary'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Epoch time
+      id: date
+      shell: bash
+      run: echo "epoch=$(date +'%s')" >> ${GITHUB_OUTPUT}
+
+    - name: Add summary
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        ## Informations for backup restore test
+        if [[ $STEP_TO_REPORT == "backup-restore" ]]; then
+          # Get Kubewarden versions
+          echo "### Kubewarden" >> ${GITHUB_STEP_SUMMARY}
+          KUBEWARDEN_VERSION=$(helm ls -n kubewarden -o json | jq ".[0].app_version")
+          echo "Kubewarden Version: $KUBEWARDEN_VERSION" >> ${GITHUB_STEP_SUMMARY}
+
+          # Get Helm Chart versions
+          echo "### Installed Helm Charts" >> ${GITHUB_STEP_SUMMARY}
+          helm ls -n kubewarden -o json | jq ".[].chart" >> ${GITHUB_STEP_SUMMARY}
+
+          # Print useful info for debugging
+          echo "### Debug Info" >> ${GITHUB_STEP_SUMMARY}
+          echo "#### Helmer Environment" >> ${GITHUB_STEP_SUMMARY}
+          ./e2e-tests/scripts/helmer.sh versions
+          ./e2e-tests/scripts/helmer.sh debug >> ${GITHUB_STEP_SUMMARY}
+
+          echo "### Backup Operator" >> ${GITHUB_STEP_SUMMARY}
+          BACKUP_OPERATOR_VERSION=$(kubectl get pod \
+            --namespace cattle-resources-system \
+            -l app.kubernetes.io/name=rancher-backup \
+            -o jsonpath={.items[*].status.containerStatuses[*].image})
+
+          echo "Backup Operator Version: $BACKUP_OPERATOR_VERSION" >> ${GITHUB_STEP_SUMMARY}
+        fi
+
+        ## Informations for airgap test
+        if [[ $STEP_TO_REPORT == "airgap_install" ]]; then
+          echo "### Airgap Installation" >> ${GITHUB_STEP_SUMMARY}
+          echo "#### Helm Charts Versions Installation" >> ${GITHUB_STEP_SUMMARY}
+          if [[ -f ./charts/hauler_manifest_prev.yaml ]]; then
+            HAULER_MANIFEST=./charts/hauler_manifest_prev.yaml
+          else
+            HAULER_MANIFEST=./charts/hauler_manifest.yaml
+          fi
+          awk '/- name:/ {name=$3} /version:/ {version=$2; print name, version}' ${HAULER_MANIFEST} >> ${GITHUB_STEP_SUMMARY}
+        fi
+
+        if [[ $STEP_TO_REPORT == "airgap_upgrade" ]]; then
+          echo "### Airgap Upgrade" >> ${GITHUB_STEP_SUMMARY}
+          echo "#### Helm Charts Versions Upgrade" >> ${GITHUB_STEP_SUMMARY}
+          HAULER_MANIFEST=./charts/hauler_manifest.yaml
+          awk '/- name:/ {name=$3} /version:/ {version=$2; print name, version}' ${HAULER_MANIFEST} >> ${GITHUB_STEP_SUMMARY}
+        fi

--- a/.github/workflows/e2e-airgap-upgrade.yml
+++ b/.github/workflows/e2e-airgap-upgrade.yml
@@ -117,6 +117,20 @@ jobs:
           KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component.outputs.kubewarden_controller_version }}
           AUDIT_SCANNER_VERSION: ${{ steps.component.outputs.audit_scanner_version }}
           POLICY_SERVER_VERSION: ${{ steps.component.outputs.policy_server_version }}
+
+      - name: Add summary
+        if: ${{ always() }}
+        env: 
+          STEP_TO_REPORT: airgap_install
+        uses: ./.github/actions/logs-and-summary
+
+      - name: Upload Hauler manifest
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: hauler_manifest_installation
+          path: ${{ github.workspace }}/charts/hauler_manifest_prev.yaml
+          retention-days: 7
       
       - name: Prepare upgrade
         working-directory: ./e2e-tests/tests/ginkgo-e2e
@@ -143,6 +157,21 @@ jobs:
           KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component_upgrade.outputs.kubewarden_controller_version }}
           AUDIT_SCANNER_VERSION: ${{ steps.component_upgrade.outputs.audit_scanner_version }}
           POLICY_SERVER_VERSION: ${{ steps.component_upgrade.outputs.policy_server_version }}
+
+      # This step must be called in each worklow that wants a summary!
+      - name: Add summary
+        if: ${{ always() }}
+        env: 
+          STEP_TO_REPORT: airgap_upgrade
+        uses: ./.github/actions/logs-and-summary
+      
+      - name: Upload Hauler manifest
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: hauler_manifest_upgrade
+          path: ${{ github.workspace }}/charts/hauler_manifest.yaml
+          retention-days: 7
 
   clean-and-delete-runner:
     needs: [create-runner, e2e]

--- a/.github/workflows/e2e-airgap.yml
+++ b/.github/workflows/e2e-airgap.yml
@@ -107,6 +107,21 @@ jobs:
           AUDIT_SCANNER_VERSION: ${{ steps.component.outputs.audit_scanner_version }}
           POLICY_SERVER_VERSION: ${{ steps.component.outputs.policy_server_version }}
       
+      # This step must be called in each worklow that wants a summary!
+      - name: Add summary
+        if: ${{ always() }}
+        env: 
+          STEP_TO_REPORT: airgap_install
+        uses: ./.github/actions/logs-and-summary
+
+      - name: Upload Hauler manifest
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: hauler_manifest.yaml
+          path: ${{ github.workspace }}/charts/hauler_manifest.yaml
+          retention-days: 7
+
   clean-and-delete-runner:
     needs: [create-runner, e2e]
     if: ${{ always() && needs.create-runner.result == 'success' && (github.event_name == 'schedule' || inputs.destroy_runner == true) }}

--- a/.github/workflows/e2e-backup-restore.yml
+++ b/.github/workflows/e2e-backup-restore.yml
@@ -83,6 +83,10 @@ jobs:
         run: |
           # Add missing PATH, removed in recent distributions for security reasons...
           echo "/usr/local/bin" >> ${GITHUB_PATH}
+
+      # Workaround, I need to take time to update the opensuse image we use in the CI
+      - name: Update helm package
+        run: sudo zypper --non-interactive update helm
       
       - name: Install K3S
         id: install_k3s
@@ -117,6 +121,18 @@ jobs:
           cd ${GITHUB_WORKSPACE}/e2e-tests/tests/ginkgo-e2e
           make e2e-install-kubewarden
           
+          # Export values
+          echo "audit_scanner_version=${AUDIT_SCANNER_VERSION}" | tee -a ${GITHUB_OUTPUT}
+          echo "backup_operator_version=${BACKUP_OPERATOR_VERSION}" | tee -a ${GITHUB_OUTPUT}
+          echo "kubewarden_controller_version=${KUBEWARDEN_CONTROLLER_VERSION}" | tee -a ${GITHUB_OUTPUT}
+          echo "policy_server_version=${POLICY_SERVER_VERSION}" | tee -a  ${GITHUB_OUTPUT}
+      # This step must be called in each worklow that wants a summary!
+      - name: Add summary
+        if: ${{ always() }}
+        env: 
+          STEP_TO_REPORT: backup-restore
+        uses: ./.github/actions/logs-and-summary
+
       - name: Test Backup/Restore kubewarden resources
         id: test_backup_restore
         run: |


### PR DESCRIPTION
## Description

Fix https://github.com/kubewarden/kubewarden-end-to-end-tests/issues/223

This PR adds summary at the end of airgap and backup restore tests to easily identify kubewarden components versions we use.

Example:
[Airgap upgrade](https://github.com/kubewarden/helm-charts/actions/runs/19163077160) ✅ 
<img width="1960" height="2054" alt="image" src="https://github.com/user-attachments/assets/cfea8d12-2530-4a44-9f77-452ea341c0a9" />

[Airgap install](https://github.com/kubewarden/helm-charts/actions/runs/19162475929) ✅ 
<img width="1810" height="1544" alt="image" src="https://github.com/user-attachments/assets/8bff30b8-4b3d-41d5-b69f-ff1a45061ff4" />

[Backup-restore](https://github.com/kubewarden/helm-charts/actions/runs/19163466385) ✅ 



