### PR TITLE
fix: make updatecli sh script POSIX compliant

### DIFF
--- a/updatecli/updatecli.d/sbomscanner_chart_sync.yaml
+++ b/updatecli/updatecli.d/sbomscanner_chart_sync.yaml
@@ -47,15 +47,17 @@ targets:
         ## Only clone the Helm chart directory that we need to sync
         git clone --depth 1 --filter=blob:none "$GIT_REPO" --sparse "$GIT_DIR"
 
-        pushd "$GIT_DIR" "$@" > /dev/null || exit 1
+        CURRENT_DIR=$PWD
+        cd "$GIT_DIR" || exit 1
         git sparse-checkout set "$GIT_DIR_SUB_PATH"
-        popd "$@" > /dev/null || exit 1
+        cd "$CURRENT_DIR" || exit 1
 
         BEFORE_CHECKSUM=""
 
-        pushd "$GIT_DIR" "$@" > /dev/null || exit 1
+        CURRENT_DIR=$PWD
+        cd "$GIT_DIR" || exit 1
         AFTER_CHECKSUM=$(find $GIT_DIR_SUB_PATH   -type f -exec md5sum {} \;)
-        popd "$@" > /dev/null || exit 1
+        cd "$CURRENT_DIR" || exit 1
 
 
         if [ -d "charts/$CHART_NAME" ]; then
@@ -66,12 +68,12 @@ targets:
         # if we are not in dry run mode
         # DRY_RUN is an environment variable set by Updatecli
         # depending if we execute `updatecli apply` or `updatecli diff`
-        if [ "$DRY_RUN" == "false" ]; then
+        if [ "$DRY_RUN" = "false" ]; then
           cp -R "$GIT_DIR/$GIT_DIR_SUB_PATH" charts/
           AFTER_CHECKSUM=$(find charts/$CHART_NAME   -type f -exec md5sum {} \;)
         fi
 
-        if [ "$BEFORE_CHECKSUM" == "$AFTER_CHECKSUM" ]; then
+        if [ "$BEFORE_CHECKSUM" = "$AFTER_CHECKSUM" ]; then
           exit 0
         fi
 


### PR DESCRIPTION
This [updatecli](https://github.com/kubewarden/helm-charts/actions/runs/18526687409/job/52799085339) pipeline is failing because the GitHub runner is executing the script using `sh` even though the script leverages some bash syntax such as  'popd/pushd'.

We could either explicitly use bash or convert the script to be sh compliant. I choose the latter. 🤷🏾 

## Description

This time I tested the pipeline from a github action running from a [fork](https://github.com/olblak/kubewarden-helm-charts/pull/4/commits/685c6e207ca2c9d203289360417e925d01f5e686) instead of "it runs on my machine"

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
