### PR TITLE
ci: add NATS helm chart dependency

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -82,6 +82,11 @@ jobs:
           helm repo add policy-reporter https://kyverno.github.io/policy-reporter
           helm repo update
 
+      - name: Add dependency repo required to release the sbomscanner chart
+        run: |
+          helm repo add policy-reporter https://nats-io.github.io/k8s/helm/charts
+          helm repo update
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:


### PR DESCRIPTION
This is required to release the SBOMscanner helm chart
