### PR TITLE
ci: fix the NATS dependency used by SBOMscanner

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Add dependency repo required to release the sbomscanner chart
         run: |
-          helm repo add policy-reporter https://nats-io.github.io/k8s/helm/charts
+          helm repo add nats https://nats-io.github.io/k8s/helm/charts
           helm repo update
 
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
Required to publish SBOMscanner
