### PR TITLE
Trigger kubewarden e2e tests only for relevant paths

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,6 +51,8 @@ on:
   pull_request:
     branches:
       - "main"
+    paths:
+      - 'charts/kubewarden-*/**'
 
   # Nightly:
   # - install from main with latest images (to check if we can tag and release)


### PR DESCRIPTION
## Description

Tests are triggered for all changes in helm-charts repository.

Limit kubewarden e2e tests trigger to not run for unrelated changes (sbomscanner, ...)

Related to https://github.com/kubewarden/helm-charts/issues/830