### PR TITLE
fix: Remove installOpenReportsCRDs as required field

### DIFF
--- a/charts/kubewarden-crds/values.schema.json
+++ b/charts/kubewarden-crds/values.schema.json
@@ -9,5 +9,7 @@
       "type": "boolean"
     }
   },
-  "required": ["installPolicyReportCRDs", "installOpenReportsCRDs"]
+  "required": [
+    "installPolicyReportCRDs"
+  ]
 }


### PR DESCRIPTION
## Description

Rancher UI is not able to properly set the `installOpenReportsCRDs` during the upgrade. Therefore, the values validation fails due the missing field. This commit removes the new field from the required field list to workaround this issue.

Fix #838 
