### PR TITLE
fix(ci): add second cosign signature for compatibility

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -159,6 +159,8 @@ jobs:
               # cosign v3.x.x because some verification tools (e.g. slsactl) are not
               # able to properly verify the signatures using this new format
               cosign sign --yes --new-bundle-format=false --use-signing-config=false "$chart_url"
+              # Sign with cosign v3 signature format as well
+              cosign sign --yes --new-bundle-format=true --use-signing-config=true "$chart_url"
               echo "Chart $chart_name signed and pushed to ghcr.io"
             done
           fi
@@ -211,11 +213,8 @@ jobs:
           cp imagelist.txt ${image_asset_name}.txt
 
           # sign hauler manifest and image list
-          # We need to disable the new bundle format enabled by default since 
-          # cosign v3.x.x because some verification tools (e.g. slsactl) are not
-          # able to properly verify the signatures using this new format
-          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false ./charts/hauler_manifest.yaml --bundle hauler_manifest_cosign.bundle
-          cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false ${image_asset_name}.txt --bundle ${image_asset_name}_cosign.bundle
+          cosign sign-blob --yes ./charts/hauler_manifest.yaml --bundle hauler_manifest_cosign.bundle
+          cosign sign-blob --yes ${image_asset_name}.txt --bundle ${image_asset_name}_cosign.bundle
 
           charts=$(find $chart_directory -maxdepth 1 -mindepth 1 -type f)
           for chart in $charts; do
@@ -232,10 +231,7 @@ jobs:
             if [[ $chart_name == *"-defaults" ]]; then
               policylist_asset_name="./charts/kubewarden-defaults/${asset_name#_}_policylist"
               cp "./charts/kubewarden-defaults/policylist.txt" ${policylist_asset_name}.txt
-              # We need to disable the new bundle format enabled by default since 
-              # cosign v3.x.x because some verification tools (e.g. slsactl) are not
-              # able to properly verify the signatures using this new format
-              cosign sign-blob --yes --new-bundle-format=false --use-signing-config=false  ${policylist_asset_name}.txt --bundle ${policylist_asset_name}_cosign.bundle
+              cosign sign-blob --yes ${policylist_asset_name}.txt --bundle ${policylist_asset_name}_cosign.bundle
               gh release upload $chart_name-$chart_version ${policylist_asset_name}.txt --clobber
               gh release upload $chart_name-$chart_version ${policylist_asset_name}_cosign.bundle --clobber
             fi


### PR DESCRIPTION
## Description

In order to allow old cosign version and other verification tools to verify the signature it's necessary to add a second signature using the old format. The default format before cosign v3 changed the default signature bundle.

Updates the CI to sign the blobs using only cosign v3 signature bundle format.

