### PR TITLE
fix: add missing namespace in skip list.

### DIFF
--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -64,6 +64,7 @@ global:
   skipNamespaces:
     - calico-apiserver
     - calico-system
+    - capi-system
     - cattle-alerting
     - cattle-csp-adapter-system
     - cattle-elemental-system
@@ -86,6 +87,7 @@ global:
     - cattle-resources-system
     - cattle-sriov-system
     - cattle-system
+    - cattle-turtles-system
     - cattle-ui-plugin-system
     - cattle-windows-gmsa-system
     - cert-manager

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -64,6 +64,7 @@ global:
   skipNamespaces:
     - calico-apiserver
     - calico-system
+    - capi-system
     - cattle-alerting
     - cattle-csp-adapter-system
     - cattle-elemental-system
@@ -86,6 +87,7 @@ global:
     - cattle-resources-system
     - cattle-sriov-system
     - cattle-system
+    - cattle-turtles-system
     - cattle-ui-plugin-system
     - cattle-windows-gmsa-system
     - cert-manager

--- a/common-values.yaml
+++ b/common-values.yaml
@@ -63,6 +63,7 @@ global:
   skipNamespaces:
     - calico-apiserver
     - calico-system
+    - capi-system
     - cattle-alerting
     - cattle-csp-adapter-system
     - cattle-elemental-system
@@ -85,6 +86,7 @@ global:
     - cattle-resources-system
     - cattle-sriov-system
     - cattle-system
+    - cattle-turtles-system
     - cattle-ui-plugin-system
     - cattle-windows-gmsa-system
     - cert-manager


### PR DESCRIPTION
## Description

Updates the list containing the namespace that should be ignore by Kubewarden by default adding two new namespaces.

