### PR TITLE
deps: remove azure/setup-helm step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,6 @@ jobs:
     steps:
       # Adapted from https://github.com/d3adb5/helm-unittest-action/
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Install Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
       - name: Install helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest
       - name: Set chart directories to test as environment variable


### PR DESCRIPTION
## Description

Github action was not updated since helm 3.9, but helm is preinstalled on github runners.

We could either:
- fix automation to bump azure/setup-helm
- remove action and use preinstalled helm

https://github.com/kubewarden/helm-charts/actions/runs/18916768588/job/54002101654?pr=847#step:3:1
```
Run azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78
  with:
    version: latest
Warning: Error while fetching latest Helm release: Error: [@octokit/auth-action] `GITHUB_TOKEN` variable is not set. It must be set on either `env:` or `with:`. See https://github.com/octokit/auth-action.js#createactionauth. Using default version v3.9.0
Downloading v3.9.0
  Request timeout: /helm-v3.9.0-linux-amd64.zip
  Waiting 11 seconds before trying again
  Request timeout: /helm-v3.9.0-linux-amd64.zip
  Waiting 17 seconds before trying again
  Error: Error: Failed to download Helm from location https://get.helm.sh/helm-v3.9.0-linux-amd64.zip
```

Release tests failed on this step: https://github.com/kubewarden/helm-charts/pull/847
