### PR TITLE
Switch to openreport branch for backup test

### DIFF
--- a/.github/workflows/e2e-backup-restore.yml
+++ b/.github/workflows/e2e-backup-restore.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           repository: viccuad/backup-restore-operator
           path: backup-restore-operator
-          ref: feat/add-kubewarden
+          ref: feat/kubewarden-openreports
 
       - name: Authenticate to GCP
         id: authenticate


### PR DESCRIPTION
## Description

Switch to openreports branch for the backup-restore test because we are still waiting on new backup-restore operator release.

## Verification run
https://github.com/kubewarden/helm-charts/actions/runs/18969644320 ✅ 