### PR TITLE
Use upstream backup-restore-operator for e2e tests

### DIFF
--- a/.github/workflows/e2e-backup-restore.yml
+++ b/.github/workflows/e2e-backup-restore.yml
@@ -53,7 +53,7 @@ jobs:
           path: e2e-tests
           submodules: 'true'
           ## REMOVE THE FOLLOWING LINE BEFORE MERGING ##
-          ref: use_backup_restore_upstream
+          ##ref: use_backup_restore_upstream
 
       - name: Authenticate to GCP
         id: authenticate


### PR DESCRIPTION
## Description

Now we get a new backup-restore operator version which can managed kubewarden resources, we can use upstream repo instead of fork.
