### PR TITLE
fix(ci): disable policy-reporter updates by renovatebot.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,10 @@
     {
       "matchPaths": ["charts/sbomscanner/**"],
       "enabled": false
+    },
+    {
+      "matchPaths": ["policy-reporter"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Description

Configure the renovate bot to ignore policy-reporter updates. This package is updated using updatecli script.

This PR is a fix the the issue found in this [PR](https://github.com/kubewarden/helm-charts/pull/870)