### PR TITLE
fix(ci): update policy-reporter tag used to fetch data.

### DIFF
--- a/updatecli/updatecli.d/update-hauler-manifest.yaml
+++ b/updatecli/updatecli.d/update-hauler-manifest.yaml
@@ -45,7 +45,7 @@ sources:
     dependson:
       - source/policy-reporterChartVersion
     spec:
-      file: 'https://raw.githubusercontent.com/kyverno/policy-reporter/refs/tags/v{{ source "source/policy-reporterChartVersion" }}/charts/policy-reporter/Chart.yaml'
+      file: 'https://raw.githubusercontent.com/kyverno/policy-reporter/refs/tags/policy-reporter-{{ source "source/policy-reporterChartVersion" }}/charts/policy-reporter/Chart.yaml'
       key: "$.appVersion"
   policyReporterChartUIImageTagValue:
     name: "Get ui.image.tag value from policy-reporter chart"
@@ -56,7 +56,7 @@ sources:
     dependson:
       - source/policy-reporterChartVersion
     spec:
-      file: 'https://raw.githubusercontent.com/kyverno/policy-reporter/refs/tags/v{{ source "source/policy-reporterChartVersion" }}/charts/policy-reporter/values.yaml'
+      file: 'https://raw.githubusercontent.com/kyverno/policy-reporter/refs/tags/policy-reporter-{{ source "source/policy-reporterChartVersion" }}/charts/policy-reporter/values.yaml'
       key: "$.ui.image.tag"
 
 # {{ if .helmCharts}}


### PR DESCRIPTION
## Description

Policy reporter uses two different tag versions in its repository. One for the `appVersion` and another to the Helm chart version. Recently, the versions start to diverge witch causes some issues when our updatecli script try to fetch the Helm chart files to extract information about the appVersion and the UI container image version in use.

This commit fixes that by updating the url used to fetch the Helm chart files to use the chart tag format.

This is an example [PR](https://github.com/jvanz/helm-charts/pull/175) created running the scripts with the changes in this PR

Fix issues found at https://github.com/kubewarden/helm-charts/pull/869.
