### PR TITLE
fix(ci): update lock file during dependencies updates.

### DIFF
--- a/updatecli/updatecli.d/update-chart-deps.yaml
+++ b/updatecli/updatecli.d/update-chart-deps.yaml
@@ -58,6 +58,23 @@ targets:
       file: "{{ $chart.file }}"
       key: "{{ $chart.versionKey }}"
   # {{ end }}
+  # {{ if eq $chart.name "policy-reporter" }}
+  target/updateDependenciesLockFile:
+    name: Call helm dependency update command to update the lock file
+    kind: shell
+    disablesourceinput: true
+    scmid: "default"
+    dependson:
+      - '{{ printf "target#target/%sChart" $chart.name }}'
+    spec:
+      command: |
+        helm dependency update charts/kubewarden-controller
+      changedif:
+        kind: file/checksum
+        spec:
+          files:
+            - charts/kubewarden-controller/Chart.lock
+  # {{ end }}
   # {{ end }}
 
 actions:


### PR DESCRIPTION
## Description

Updates the updatecli script to call helm dependency update command. Therefore, the Chart.lock file will be update together with the dependencies updated from Chart.yaml of the kubewarden-controller chart.

