### PR TITLE
Fix images version to use in airgap e2e tests

### DIFF
--- a/.github/workflows/e2e-airgap-upgrade.yml
+++ b/.github/workflows/e2e-airgap-upgrade.yml
@@ -101,22 +101,27 @@ jobs:
         run: |
           HAULER_MANIFEST=./charts/hauler_manifest_prev.yaml
 
-          AUDIT_SCANNER_VERSION=$(grep 'audit-scanner:v' ${HAULER_MANIFEST} | cut -d':' -f3)
-          KUBEWARDEN_CONTROLLER_VERSION=$(grep 'kubewarden-controller:v' ${HAULER_MANIFEST} | cut -d':' -f3)
-          POLICY_SERVER_VERSION=$(grep 'policy-server:v' ${HAULER_MANIFEST} | cut -d':' -f3)
-
-          # Export values
-          echo "audit_scanner_version=${AUDIT_SCANNER_VERSION}" | tee -a ${GITHUB_OUTPUT}
-          echo "kubewarden_controller_version=${KUBEWARDEN_CONTROLLER_VERSION}" | tee -a ${GITHUB_OUTPUT}
-          echo "policy_server_version=${POLICY_SERVER_VERSION}" | tee -a  ${GITHUB_OUTPUT}
+          images=(
+            audit-scanner
+            kubewarden-controller
+            policy-server
+          )
+          
+          for image in "${images[@]}"; do
+            version=$(grep "${image}:v" "$HAULER_MANIFEST" | cut -d':' -f3)
+            output_var="${image//-/_}"
+          
+            # EXPORT VALUES FOR NEXT STEPS
+            echo "${output_var}=${version}" | tee -a "$GITHUB_OUTPUT"
+          done
 
       - name: Deploy airgap infrastructure
         id: deploy_airgap_infra
         run: cd ${GITHUB_WORKSPACE}/e2e-tests/tests/ginkgo-e2e && make e2e-airgap-rancher
         env:
-          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component.outputs.kubewarden_controller_version }}
-          AUDIT_SCANNER_VERSION: ${{ steps.component.outputs.audit_scanner_version }}
-          POLICY_SERVER_VERSION: ${{ steps.component.outputs.policy_server_version }}
+          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component.outputs.kubewarden_controller }}
+          AUDIT_SCANNER_VERSION: ${{ steps.component.outputs.audit_scanner }}
+          POLICY_SERVER_VERSION: ${{ steps.component.outputs.policy_server }}
 
       - name: Add summary
         if: ${{ always() }}
@@ -141,22 +146,39 @@ jobs:
         run: |
           HAULER_MANIFEST=./charts/hauler_manifest.yaml
 
-          AUDIT_SCANNER_VERSION=$(grep 'audit-scanner:v' ${HAULER_MANIFEST} | cut -d':' -f3)
-          KUBEWARDEN_CONTROLLER_VERSION=$(grep 'kubewarden-controller:v' ${HAULER_MANIFEST} | cut -d':' -f3)
-          POLICY_SERVER_VERSION=$(grep 'policy-server:v' ${HAULER_MANIFEST} | cut -d':' -f3)
-
-          # Export values
-          echo "audit_scanner_version=${AUDIT_SCANNER_VERSION}" | tee -a ${GITHUB_OUTPUT}
-          echo "kubewarden_controller_version=${KUBEWARDEN_CONTROLLER_VERSION}" | tee -a ${GITHUB_OUTPUT}
-          echo "policy_server_version=${POLICY_SERVER_VERSION}" | tee -a  ${GITHUB_OUTPUT}
+          images=(
+            audit-scanner
+            kubewarden-controller
+            policy-server
+            allow-privilege-escalation-psp
+            capabilities-psp
+            host-namespaces-psp
+            hostpaths-psp
+            pod-privileged
+            user-group-psp
+          )
+          
+          for image in "${images[@]}"; do
+            version=$(grep "${image}:v" "$HAULER_MANIFEST" | cut -d':' -f3)
+            output_var="${image//-/_}"
+          
+            # EXPORT VALUES FOR NEXT STEPS
+            echo "${output_var}=${version}" | tee -a "$GITHUB_OUTPUT"
+          done
 
       - name: Upgrade Kubewarden
         working-directory: ./e2e-tests/tests/ginkgo-e2e
         run: make e2e-airgap-upgrade
         env:
-          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component_upgrade.outputs.kubewarden_controller_version }}
-          AUDIT_SCANNER_VERSION: ${{ steps.component_upgrade.outputs.audit_scanner_version }}
-          POLICY_SERVER_VERSION: ${{ steps.component_upgrade.outputs.policy_server_version }}
+          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component_upgrade.outputs.kubewarden_controller }}
+          AUDIT_SCANNER_VERSION: ${{ steps.component_upgrade.outputs.audit_scanner }}
+          POLICY_SERVER_VERSION: ${{ steps.component_upgrade.outputs.policy_server }}
+          ALLOW_PRIVILEGE_ESCALATION_PSP_VERSION: ${{ steps.component_upgrade.outputs.allow_privilege_escalation_psp }}
+          CAPABILITIES_PSP_VERSION: ${{ steps.component_upgrade.outputs.capabilities_psp }}
+          HOST_NAMESPACES_PSP_VERSION: ${{ steps.component_upgrade.outputs.host_namespaces_psp }}
+          HOSTPATHS_PSP_VERSION: ${{ steps.component_upgrade.outputs.hostpaths_psp }}
+          POD_PRIVILEGED_PSP_VERSION: ${{ steps.component_upgrade.outputs.pod_privileged }}
+          USER_GROUP_PSP_VERSION: ${{ steps.component_upgrade.outputs.user_group_psp }}
 
       # This step must be called in each worklow that wants a summary!
       - name: Add summary

--- a/.github/workflows/e2e-airgap.yml
+++ b/.github/workflows/e2e-airgap.yml
@@ -90,22 +90,39 @@ jobs:
         run: |
           HAULER_MANIFEST=./charts/hauler_manifest.yaml
 
-          AUDIT_SCANNER_VERSION=$(grep 'audit-scanner:v' ${HAULER_MANIFEST} | cut -d':' -f3)
-          KUBEWARDEN_CONTROLLER_VERSION=$(grep 'kubewarden-controller:v' ${HAULER_MANIFEST} | cut -d':' -f3)
-          POLICY_SERVER_VERSION=$(grep 'policy-server:v' ${HAULER_MANIFEST} | cut -d':' -f3)
-
-          # Export values
-          echo "audit_scanner_version=${AUDIT_SCANNER_VERSION}" | tee -a ${GITHUB_OUTPUT}
-          echo "kubewarden_controller_version=${KUBEWARDEN_CONTROLLER_VERSION}" | tee -a ${GITHUB_OUTPUT}
-          echo "policy_server_version=${POLICY_SERVER_VERSION}" | tee -a  ${GITHUB_OUTPUT}
+          images=(
+            audit-scanner
+            kubewarden-controller
+            policy-server
+            allow-privilege-escalation-psp
+            capabilities-psp
+            host-namespaces-psp
+            hostpaths-psp
+            pod-privileged
+            user-group-psp
+          )
+          
+          for image in "${images[@]}"; do
+            version=$(grep "${image}:v" "$HAULER_MANIFEST" | cut -d':' -f3)
+            output_var="${image//-/_}"
+          
+            # EXPORT VALUES FOR NEXT STEPS
+            echo "${output_var}=${version}" | tee -a "$GITHUB_OUTPUT"
+          done
 
       - name: Deploy airgap infrastructure
         id: deploy_airgap_infra
         run: cd ${GITHUB_WORKSPACE}/e2e-tests/tests/ginkgo-e2e && make e2e-airgap-rancher
         env:
-          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component.outputs.kubewarden_controller_version }}
-          AUDIT_SCANNER_VERSION: ${{ steps.component.outputs.audit_scanner_version }}
-          POLICY_SERVER_VERSION: ${{ steps.component.outputs.policy_server_version }}
+          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component.outputs.kubewarden_controller }}
+          AUDIT_SCANNER_VERSION: ${{ steps.component.outputs.audit_scanner }}
+          POLICY_SERVER_VERSION: ${{ steps.component.outputs.policy_server }}
+          ALLOW_PRIVILEGE_ESCALATION_PSP_VERSION: ${{ steps.component.outputs.allow_privilege_escalation_psp }}
+          CAPABILITIES_PSP_VERSION: ${{ steps.component.outputs.capabilities_psp }}
+          HOST_NAMESPACES_PSP_VERSION: ${{ steps.component.outputs.host_namespaces_psp }}
+          HOSTPATHS_PSP_VERSION: ${{ steps.component.outputs.hostpaths_psp }}
+          POD_PRIVILEGED_PSP_VERSION: ${{ steps.component.outputs.pod_privileged }}
+          USER_GROUP_PSP_VERSION: ${{ steps.component.outputs.user_group_psp }}
       
       # This step must be called in each worklow that wants a summary!
       - name: Add summary


### PR DESCRIPTION
## Description

Fix issue that happens when we bump new recommended policies, the hauler manifest is updated but there is a mismatch with the file policy.txt from the helm chart (pull from the hauler file too).
With this PR, we force the policy version we got from the hauler manifest.

## Verification test
[Airgap upgrade](https://github.com/kubewarden/helm-charts/actions/runs/20777213300) ✅ 
[Airgap](https://github.com/kubewarden/helm-charts/actions/runs/20776929712) ✅ 

Part of https://github.com/kubewarden/kubewarden-end-to-end-tests/pull/260