### PR TITLE
Add cattle-capi-system to skipped namespaces

### DIFF
--- a/charts/kubewarden-controller/values.yaml
+++ b/charts/kubewarden-controller/values.yaml
@@ -65,6 +65,7 @@ global:
     - calico-apiserver
     - calico-system
     - capi-system
+    - cattle-capi-system
     - cattle-alerting
     - cattle-csp-adapter-system
     - cattle-elemental-system
@@ -149,9 +150,9 @@ logLevel: info
 # open-telemetry options
 telemetry:
   # Kubewarden controller telemetry configuration allow two OpenTelemetry
-  # collector communication options: 
+  # collector communication options:
   # - sidecar: It will create a Otel collector sidecar and configure the
-  # controller and policy server to send metrics and traces to it. 
+  # controller and policy server to send metrics and traces to it.
   # - custom: It will configure the controller and policy server to send metrics
   # and traces to a custom collector that is not running as a sidecar.
 
@@ -192,7 +193,7 @@ telemetry:
     otelCollectorClientCertificateSecret: ""
 
   # The following settings are used to configure the Prometheus metrics and
-  # Jaeger tracing when sidecar mode is used. Otherwise, these settings are ignored 
+  # Jaeger tracing when sidecar mode is used. Otherwise, these settings are ignored
   sidecar:
     # telemetry.sidecar.metrics is used to configure the Prometheus metrics exporter
     # in the Otel collector sidecar
@@ -260,7 +261,7 @@ mTLS:
   # policy-servers and the Kubernetes API server, as well as between the
   # policy-servers and the audit-scanner.
   # Enabling this feature will require the Kubernetes API server to be
-  # configured. If that is not achievable, consider using a service mesh. 
+  # configured. If that is not achievable, consider using a service mesh.
   enable: false
   # name of the ConfigMap in kubewarden-controller namespace containing the
   # client CA certificate. The ConfigMap must contain a data.client-ca.crt key

--- a/charts/kubewarden-defaults/values.yaml
+++ b/charts/kubewarden-defaults/values.yaml
@@ -65,6 +65,7 @@ global:
     - calico-apiserver
     - calico-system
     - capi-system
+    - cattle-capi-system
     - cattle-alerting
     - cattle-csp-adapter-system
     - cattle-elemental-system

--- a/common-values.yaml
+++ b/common-values.yaml
@@ -64,6 +64,7 @@ global:
     - calico-apiserver
     - calico-system
     - capi-system
+    - cattle-capi-system
     - cattle-alerting
     - cattle-csp-adapter-system
     - cattle-elemental-system


### PR DESCRIPTION
## Description

CAPI changed namespace in rancher 2.13

<img width="1600" height="900" alt="test-failed-1" src="https://github.com/user-attachments/assets/50d173ac-b050-4f51-8462-e2115ff35dc8" />
