### PR TITLE
ci: Generate charts CHANGELOG.md from monorepo only

### DIFF
--- a/scripts/generate_changelog_files.sh
+++ b/scripts/generate_changelog_files.sh
@@ -5,18 +5,11 @@ CHART_DIR=$1
 IMAGELIST_FILENAME=$2
 TMP_CHANGELOG_FILE_PATH=/tmp/changelog.md
 
-CONTROLLER_VERSION=$(grep "kubewarden-controller" < "$IMAGELIST_FILENAME" | sed "s/.*kubewarden-controller:\(\)/\1/g")
-CONTROLLER_URL=$(gh release view "$CONTROLLER_VERSION" --repo kubewarden/kubewarden-controller --json "url" | jq -r ".url" )
-POLICY_SERVER_VERSION=$(grep "policy-server" < "$IMAGELIST_FILENAME" | sed "s/.*policy-server:\(\)/\1/g")
-POLICY_SERVER_URL=$(gh release view "$POLICY_SERVER_VERSION" --repo kubewarden/policy-server --json "url" | jq -r ".url" )
-AUDIT_SCANNER_VERSION=$(grep "audit-scanner" < "$IMAGELIST_FILENAME" | sed "s/.*audit-scanner:\(\)/\1/g")
-AUDIT_SCANNER_URL=$(gh release view "$AUDIT_SCANNER_VERSION" --repo kubewarden/audit-scanner --json "url" | jq -r ".url" )
+CONTROLLER_VERSION=$(grep "kubewarden-controller" <"$IMAGELIST_FILENAME" | sed "s/.*kubewarden-controller:\(\)/\1/g")
+CONTROLLER_URL=$(gh release view "$CONTROLLER_VERSION" --repo kubewarden/kubewarden-controller --json "url" | jq -r ".url")
 {
-  echo "Kubewarden controller [changelog]($CONTROLLER_URL)"
-  echo "Policy server [changelog]($POLICY_SERVER_URL)"
-  echo "Audit scanner [changelog]($AUDIT_SCANNER_URL)"
-} >> $TMP_CHANGELOG_FILE_PATH
+  echo "Kubewarden Admission Controller [changelog]($CONTROLLER_URL)"
+} >>$TMP_CHANGELOG_FILE_PATH
 cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-controller/CHANGELOG.md"
 cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-defaults/CHANGELOG.md"
 cp $TMP_CHANGELOG_FILE_PATH "$CHART_DIR/kubewarden-crds/CHANGELOG.md"
-


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Before, we were obtaining the changelogs from the different several repos.

Now, we only need the changelog from the monorepo at `kubewarden/kubewarden-controller`.

This fixes the chart release job, as we call
`make generate-changelog-files` on release.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested locally with `make generate-changelog-files`

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
