### PR TITLE
Run airgap tests from PR

### DIFF
--- a/.github/workflows/e2e-airgap-upgrade.yml
+++ b/.github/workflows/e2e-airgap-upgrade.yml
@@ -19,9 +19,13 @@ on:
         description: GCP zone to host the runner
         default: us-central1-f
         type: string
-  schedule:
-    # Every Friday at 8am UTC (10pm in us-central1)
-    - cron: '0 8 * * 5'
+
+  # Run test from PR
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - 'charts/kubewarden-*/**'
 
 jobs:
   create-runner:

--- a/.github/workflows/e2e-airgap.yml
+++ b/.github/workflows/e2e-airgap.yml
@@ -19,9 +19,13 @@ on:
         description: GCP zone to host the runner
         default: us-central1-f
         type: string
-  schedule:
-    # Every Friday at 3am UTC (10pm in us-central1)
-    - cron: '0 3 * * 5'
+
+  # Run test from PR
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - 'charts/kubewarden-*/**'
 
 jobs:
   create-runner:


### PR DESCRIPTION
## Description

Trigger airgap tests from pull request instead of weekly scheduling (every friday).

I don't know if we want to trigger them for every PR or if we want to do it only for release, we will see.