### PR TITLE
fix hauler image versions

### DIFF
--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -47,8 +47,8 @@ metadata:
 spec:
   images:
     - name: ghcr.io/kyverno/policy-reporter-ui:2.5.1
-    - name: ghcr.io/kyverno/policy-reporter:3.7.1
-    - name: ghcr.io/rancher/kuberlr-kubectl:v6.0.0
+    - name: ghcr.io/kyverno/policy-reporter:3.7.0
+    - name: ghcr.io/rancher/kuberlr-kubectl:v7.0.0
 ---
 apiVersion: content.hauler.cattle.io/v1
 kind: Charts


### PR DESCRIPTION
I didn't find hauler manifest on manorepo so I am opening draft PR here.

### Policy reporter
Policy reporter image version does not match policy-reporter version

values.yaml has `tag: ~`, so app version is used
https://github.com/kyverno/policy-reporter/blob/main/charts/policy-reporter/values.yaml#L22

```
~ helm search repo policy-reporter
NAME                           	CHART VERSION	APP VERSION	DESCRIPTION                                       
policy-reporter/policy-reporter	3.7.1        	3.7.0

# when I install policy-reporter it uses 3.7.0 image
k get pods -n policy-reporter policy-reporter-68c8f7c65c-kvh7p -o yaml | grep image
    image: ghcr.io/kyverno/policy-reporter:3.7.0
```

Nightly e2e tests fail on this https://github.com/kubewarden/helm-charts/actions/runs/21494656370/job/61926170803