### PR TITLE
Revert "Run airgap tests from PR"

### DIFF
--- a/.github/workflows/e2e-airgap-upgrade.yml
+++ b/.github/workflows/e2e-airgap-upgrade.yml
@@ -19,13 +19,9 @@ on:
         description: GCP zone to host the runner
         default: us-central1-f
         type: string
-
-  # Run test from PR
-  pull_request:
-    branches:
-      - "main"
-    paths:
-      - 'charts/kubewarden-*/**'
+  schedule:
+    # Every Friday at 8am UTC (10pm in us-central1)
+    - cron: '0 8 * * 5'
 
 jobs:
   create-runner:

--- a/.github/workflows/e2e-airgap.yml
+++ b/.github/workflows/e2e-airgap.yml
@@ -19,13 +19,9 @@ on:
         description: GCP zone to host the runner
         default: us-central1-f
         type: string
-
-  # Run test from PR
-  pull_request:
-    branches:
-      - "main"
-    paths:
-      - 'charts/kubewarden-*/**'
+  schedule:
+    # Every Friday at 3am UTC (10pm in us-central1)
+    - cron: '0 3 * * 5'
 
 jobs:
   create-runner:


### PR DESCRIPTION
Reverts kubewarden/helm-charts#907

Airgap test cannot be triggered from fork due to security issue with SECRETS, I will have to find a better solution.