### PR TITLE
fix(ci): Adm Con chart sync job should not sync docs/

### DIFF
--- a/updatecli/updatecli.d/adm_controller_chart_sync.yaml
+++ b/updatecli/updatecli.d/adm_controller_chart_sync.yaml
@@ -51,6 +51,9 @@ targets:
         git sparse-checkout set "$GIT_DIR_SUB_PATH"
         cd "$CURRENT_DIR" || exit 1
 
+        # Remove things that we don't want to be copied
+        rm -Rf "$GIT_DIR/$GIT_DIR_SUB_PATH"/kubewarden-crds/docs
+
         # Calculate checksum of all charts before update
         BEFORE_CHECKSUM=""
         if [ -d "$CHARTS_DIR" ]; then
@@ -62,6 +65,9 @@ targets:
         cd "$GIT_DIR" || exit 1
         AFTER_CHECKSUM=$(find "$GIT_DIR_SUB_PATH" -type f -exec sha256sum {} \;)
         cd "$CURRENT_DIR" || exit 1
+
+        # Remove subcharts, we only want the last tgz there
+        rm -rf "$CHARTS_DIR/kubewarden-controller"/charts/*
 
         # To keep Updatecli idempotent, we only change the files
         # if we are not in dry run mode


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/helm-charts/issues/908

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->
While syncing:

- Do not sync `kubewarden-crds/docs/` folder
- Subsitutue old subcharts under `kubewarden-controller/charts`, as we
only want to ship the subchart tgz of the subchart we declare under
Chart.lock. We still need to ship the tgz for airgap scenarios.



## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested by running the bash script locally:
```
        modified:   charts/kubewarden-controller/Chart.lock
        modified:   charts/kubewarden-controller/Chart.yaml
        new file:   charts/kubewarden-controller/charts/policy-reporter-3.7.0.tgz
        deleted:    charts/kubewarden-controller/charts/policy-reporter-3.7.1.tgz
        modified:   charts/kubewarden-defaults/templates/policyserver-default.yaml
```


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
