### PR TITLE
chore!: Don't publish imagelist.txt,policylist.txt artifacts

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -202,19 +202,8 @@ jobs:
             exit 0
           fi
 
-          charts=$(find ./charts -maxdepth 1 -mindepth 1 -type d)
-          asset_name=""
-          for chart in $charts; do
-            chart_name=$(helm show chart $chart | yq -r '.name' )
-            chart_version=$(helm show chart $chart | yq -r '.version')
-            asset_name="${asset_name}_${chart_name}-${chart_version}"
-          done
-          image_asset_name="${asset_name#_}_images"
-          cp imagelist.txt ${image_asset_name}.txt
-
           # sign hauler manifest and image list
           cosign sign-blob --yes ./charts/hauler_manifest.yaml --bundle hauler_manifest_cosign.bundle
-          cosign sign-blob --yes ${image_asset_name}.txt --bundle ${image_asset_name}_cosign.bundle
 
           charts=$(find $chart_directory -maxdepth 1 -mindepth 1 -type f)
           for chart in $charts; do
@@ -223,18 +212,6 @@ jobs:
             # upload hauler manifest and its verification bundle
             gh release upload $chart_name-$chart_version ./charts/hauler_manifest.yaml --clobber
             gh release upload $chart_name-$chart_version hauler_manifest_cosign.bundle --clobber
-            if [[ $chart_name != *"-crds" ]]; then
-              # updaload image list and its verification bundle
-              gh release upload $chart_name-$chart_version ${image_asset_name}.txt --clobber
-              gh release upload $chart_name-$chart_version ${image_asset_name}_cosign.bundle --clobber
-            fi
-            if [[ $chart_name == *"-defaults" ]]; then
-              policylist_asset_name="./charts/kubewarden-defaults/${asset_name#_}_policylist"
-              cp "./charts/kubewarden-defaults/policylist.txt" ${policylist_asset_name}.txt
-              cosign sign-blob --yes ${policylist_asset_name}.txt --bundle ${policylist_asset_name}_cosign.bundle
-              gh release upload $chart_name-$chart_version ${policylist_asset_name}.txt --clobber
-              gh release upload $chart_name-$chart_version ${policylist_asset_name}_cosign.bundle --clobber
-            fi
           done
 
       - name: Generate provenance attestation for kubewarden-crds chart and push to OCI


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Part of https://github.com/kubewarden/helm-charts/issues/905.

Stop publishing GH release artifacts for imagelist.txt and policylist.txt, together with their signatures.

That is, artifacts in the form of:

```
kubewarden-controller-5.10.0-rc3_kubewarden-crds-1.24.0-rc3_sbomscanner-0.9.0_kubewarden-defaults-3.9.1_images.txt
```

This simplifies releases of different components, as we don't need to add non-trivial logic to separate SBOMscanner and Adm Controller.

As always, each of the chart already includes an imagelist.txt and policylist.txt (when applicable), which can be obtained by doing a `helm pull`.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Untested.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
