### PR TITLE
fix: Copy hauler_manifest.yaml as part of updatecli pipeline

### DIFF
--- a/updatecli/updatecli.d/adm_controller_chart_sync.yaml
+++ b/updatecli/updatecli.d/adm_controller_chart_sync.yaml
@@ -66,14 +66,15 @@ targets:
         AFTER_CHECKSUM=$(find "$GIT_DIR_SUB_PATH" -type f -exec sha256sum {} \;)
         cd "$CURRENT_DIR" || exit 1
 
-        # Remove subcharts, we only want the last tgz there
-        rm -rf "$CHARTS_DIR/kubewarden-controller"/charts/*
-
         # To keep Updatecli idempotent, we only change the files
         # if we are not in dry run mode
         # DRY_RUN is an environment variable set by Updatecli
         # depending if we execute `updatecli apply` or `updatecli diff`
         if [ "$DRY_RUN" = "false" ]; then
+
+           # Remove subcharts, we only want the last tgz there
+           rm -rf "$CHARTS_DIR/kubewarden-controller"/charts/*
+
            for chart in "$GIT_DIR/$GIT_DIR_SUB_PATH"/*; do
              if [ -d "$chart" ]; then
                cp -R "$chart" "$CHARTS_DIR/"


### PR DESCRIPTION
## Description

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

The hauler_manifest.yaml is not copied/updated as part of the https://github.com/kubewarden/helm-charts/blob/main/.github/workflows/update-adm-controller.yaml pipeline.

See https://github.com/kubewarden/helm-charts/pull/923.

This fixes it.

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Tested this locally by copying the contents to a script and doing `DRY_RUN=false copy.sh`

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
