### PR TITLE
Enable Renovate subchart archive updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
   "labels": [
     "area/dependencies"
   ],
+  "postUpdateOptions": [
+    "helmUpdateSubChartArchives"
+  ],
   "packageRules": [
     {
       "matchPackageNames": [
@@ -16,25 +19,8 @@
       "enabled": false
     },
     {
-      "matchPaths": [
+      "matchFileNames": [
         "charts/sbomscanner/**"
-      ],
-      "enabled": false
-    },
-    {
-      "matchManagers": [
-        "helm-values",
-        "helmfile",
-        "helm-chart"
-      ],
-      "matchPackageNames": [
-        "policy-reporter"
-      ],
-      "matchDatasources": [
-        "helm"
-      ],
-      "matchSourceUrls": [
-        "https://kyverno.github.io/policy-reporter"
       ],
       "enabled": false
     }


### PR DESCRIPTION
## Summary

- enable Renovate's helmUpdateSubChartArchives post-update option so Helm dependency bumps can refresh packaged subchart archives under charts/
- re-enable Renovate updates for the policy-reporter Helm dependency now that subchart archives can be updated
- migrate the existing sbomscanner package rule from matchPaths to matchFileNames per Renovate config validation

Renovate's Helm v3 docs describe helmUpdateSubChartArchives for exactly this case: https://docs.renovatebot.com/modules/manager/helmv3/#subchart-archives

Fixes #316.

## Testing

- jq empty renovate.json
- npx --yes --package renovate renovate-config-validator renovate.json
- helm dependency update charts/kubewarden-controller
- git diff --check