### PR TITLE
ci(airgap): Set the k3s binary and image checksum

### DIFF
--- a/.github/workflows/e2e-airgap-upgrade.yml
+++ b/.github/workflows/e2e-airgap-upgrade.yml
@@ -11,6 +11,14 @@ on:
         description: K3S version to use
         type: string
         default: 'v1.31.7+k3s1'
+      k3s_binary_checksum:
+        description: sha256 of k3s binary for the K3S version in use
+        type: string
+        default: "77077df352d91b5a803113d2d98f94a267d1680222f04a0fd76b2aed646f9344"
+      k3s_images_checksum:
+        description: sha256 of k3s-airgap-images-amd64.tar.zst for the K3S version in use
+        type: string
+        default: "2666c3880447979079b94babccf12296706167a5747a0f94962b257bda442449"
       local_helm_repository:
         description: Local Helm repository URL to use in the test
         default: false
@@ -49,7 +57,9 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.runner_label }}
     env:
       K3S_VERSION: ${{ inputs.k3s_version || 'v1.31.7+k3s1' }}
-      TEST_TYPE: upgrade 
+      K3S_BINARY_SHA256: ${{ inputs.k3s_binary_checksum || '77077df352d91b5a803113d2d98f94a267d1680222f04a0fd76b2aed646f9344' }}
+      K3S_AIRGAP_IMAGES_SHA256: ${{ inputs.k3s_images_checksum || '2666c3880447979079b94babccf12296706167a5747a0f94962b257bda442449' }}
+      TEST_TYPE: upgrade
     steps:
       - name: Checkout
         id: checkout


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Just as we do for the e2e-airgap.yml workflow already

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Untested. Same as the e2e-airgap.yml workflow.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
