### PR TITLE
fix(ci): update image name in airgap E2E version extraction

### DIFF
--- a/.github/workflows/e2e-airgap-upgrade.yml
+++ b/.github/workflows/e2e-airgap-upgrade.yml
@@ -133,7 +133,7 @@ jobs:
 
           images=(
             audit-scanner
-            kubewarden-controller
+            controller
             policy-server
           )
           
@@ -149,7 +149,7 @@ jobs:
         id: deploy_airgap_infra
         run: cd ${GITHUB_WORKSPACE}/e2e-tests/tests/ginkgo-e2e && make e2e-airgap-rancher
         env:
-          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component.outputs.kubewarden_controller }}
+          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component.outputs.controller }}
           AUDIT_SCANNER_VERSION: ${{ steps.component.outputs.audit_scanner }}
           POLICY_SERVER_VERSION: ${{ steps.component.outputs.policy_server }}
 
@@ -184,7 +184,7 @@ jobs:
 
           images=(
             audit-scanner
-            kubewarden-controller
+            controller
             policy-server
             allow-privilege-escalation-psp
             capabilities-psp
@@ -206,7 +206,7 @@ jobs:
         working-directory: ./e2e-tests/tests/ginkgo-e2e
         run: make e2e-airgap-upgrade
         env:
-          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component_upgrade.outputs.kubewarden_controller }}
+          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component_upgrade.outputs.controller }}
           AUDIT_SCANNER_VERSION: ${{ steps.component_upgrade.outputs.audit_scanner }}
           POLICY_SERVER_VERSION: ${{ steps.component_upgrade.outputs.policy_server }}
           ALLOW_PRIVILEGE_ESCALATION_PSP_VERSION: ${{ steps.component_upgrade.outputs.allow_privilege_escalation_psp }}

--- a/.github/workflows/e2e-airgap.yml
+++ b/.github/workflows/e2e-airgap.yml
@@ -118,7 +118,7 @@ jobs:
 
           images=(
             audit-scanner
-            kubewarden-controller
+            controller
             policy-server
             allow-privilege-escalation-psp
             capabilities-psp
@@ -140,7 +140,7 @@ jobs:
         id: deploy_airgap_infra
         run: cd ${GITHUB_WORKSPACE}/e2e-tests/tests/ginkgo-e2e && make e2e-airgap-rancher
         env:
-          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component.outputs.kubewarden_controller }}
+          KUBEWARDEN_CONTROLLER_VERSION: ${{ steps.component.outputs.controller }}
           AUDIT_SCANNER_VERSION: ${{ steps.component.outputs.audit_scanner }}
           POLICY_SERVER_VERSION: ${{ steps.component.outputs.policy_server }}
           ALLOW_PRIVILEGE_ESCALATION_PSP_VERSION: ${{ steps.component.outputs.allow_privilege_escalation_psp }}


### PR DESCRIPTION
## Description

The container image was renamed from kubewarden-controller to adm-controller/controller as part of the repository rename. Update the grep pattern in the airgap workflows to match the new image name and fix the corresponding output variable references.

Issue found during this [PR](https://github.com/kubewarden/helm-charts/pull/998) review