### PR TITLE
fix: issue in the helm chart release CI due the container image renaming

### DIFF
--- a/scripts/generate_changelog_files.sh
+++ b/scripts/generate_changelog_files.sh
@@ -5,8 +5,8 @@ CHART_DIR=$1
 IMAGELIST_FILENAME=$2
 TMP_CHANGELOG_FILE_PATH=/tmp/changelog.md
 
-CONTROLLER_VERSION=$(grep "kubewarden-controller" <"$IMAGELIST_FILENAME" | sed "s/.*kubewarden-controller:\(\)/\1/g")
-CONTROLLER_URL=$(gh release view "$CONTROLLER_VERSION" --repo kubewarden/kubewarden-controller --json "url" | jq -r ".url")
+CONTROLLER_VERSION=$(grep "adm-controller/controller" <"$IMAGELIST_FILENAME" | sed "s/.*adm-controller\/controller:\(.*\)/\1/g")
+CONTROLLER_URL=$(gh release view "$CONTROLLER_VERSION" --repo kubewarden/adm-controller --json "url" | jq -r ".url")
 {
   echo "Kubewarden Admission Controller [changelog]($CONTROLLER_URL)"
 } >>$TMP_CHANGELOG_FILE_PATH

--- a/scripts/generate_changelog_files.sh
+++ b/scripts/generate_changelog_files.sh
@@ -5,6 +5,9 @@ CHART_DIR=$1
 IMAGELIST_FILENAME=$2
 TMP_CHANGELOG_FILE_PATH=/tmp/changelog.md
 
+# Clear the temp file before writing
+rm -f $TMP_CHANGELOG_FILE_PATH
+
 CONTROLLER_VERSION=$(grep "adm-controller/controller" <"$IMAGELIST_FILENAME" | sed "s/.*adm-controller\/controller:\(.*\)/\1/g")
 CONTROLLER_URL=$(gh release view "$CONTROLLER_VERSION" --repo kubewarden/adm-controller --json "url" | jq -r ".url")
 {


### PR DESCRIPTION
## Description

The CI to release the Helm charts is not working properly because of the container image renaming, the script used to generate the change log is not working. This PR fix this issue

This PS also fix another issue. When the Makefile target is called in the local workstation, the changelog generated locally is appending lines for different version. This is not related to the renaming issue. It's just an issue found during the fix for the first issue. 

Part of https://github.com/kubewarden/adm-controller/issues/1657
