### PR TITLE
fix(chart): fix kubewarden-defaults version

### DIFF
--- a/charts/hauler_manifest.yaml
+++ b/charts/hauler_manifest.yaml
@@ -64,7 +64,7 @@ spec:
       version: 5.14.0-beta.1
     - name: kubewarden-defaults
       repoURL: https://charts.kubewarden.io
-      version: 3.14.0-alpha
+      version: 3.14.0-beta.1
     - name: policy-reporter
       version: 3.7.4
       repoURL: https://kyverno.github.io/policy-reporter

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.14.0-alpha
+version: 3.14.0-beta.1
 # This is the version of Kubewarden stack
 appVersion: v1.36.0-beta.1
 annotations:


### PR DESCRIPTION
## Description

Updates the kubewarden-defaults helm chart version updating the suffix to beta.1 as done for the others helm charts.

