### PR TITLE
Bump k3d to 5.9.0

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -82,9 +82,9 @@ defaults:
     shell: bash
 
 env:
-  K3D_VERSION: v5.8.3
-  K3D_CHECKSUM_AMD64: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
-  K3D_CHECKSUM_ARM64: 0b8110f2229631af7402fb828259330985918b08fefd38b7f1b788a1c8687216
+  K3D_VERSION: v5.9.0
+  K3D_CHECKSUM_AMD64: 06d8f25bc3a971c4eb29e0ff08429b180402db0f4dec838c9eac427e296800a0
+  K3D_CHECKSUM_ARM64: 03cde5cf23e6e8e67de5a039ecf26e5b85aca82fba3e5d13dadf904cd218a250
   K3D_CLUSTER_NAME: ${{ github.repository_owner }}-${{ github.event.repository.name }}-runner
   MTLS: ${{ github.event_name == 'schedule' && 'true' || inputs.MTLS }}
 


### PR DESCRIPTION
## Description

Bump k3d version to 5.9.0, which is security releasem described in https://github.com/k3d-io/k3d/issues/1669
