### PR TITLE
fix(renovate): ignore all charts/ dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
     "schedule:earlyMondays",
     "helpers:pinGitHubActionDigests"
   ],
+  "ignorePaths": [
+    "charts/**"
+  ],
   "labels": [
     "area/dependencies"
   ],
@@ -12,12 +15,6 @@
     {
       "matchPackageNames": [
         "/.*kyverno/policy-reporter-ui/"
-      ],
-      "enabled": false
-    },
-    {
-      "matchPaths": [
-        "charts/sbomscanner/**"
       ],
       "enabled": false
     },


### PR DESCRIPTION
## Summary

All Helm charts under `charts/` are synced automatically from upstream
component repositories. Dependency updates must be made there, not here —
so Renovate PRs against these files (e.g. #1019) are noise.

This replaces the existing per-chart `matchPaths` override for
`charts/sbomscanner/**` with a single top-level `ignorePaths: ["charts/**"]`,
covering all synced charts. GitHub Actions workflows and other root-level
dependencies are unaffected.

Fixes #1022