### PR TITLE
fix(scripts): several fixes in the image and policy list generation script

### DIFF
--- a/scripts/extract_images.sh
+++ b/scripts/extract_images.sh
@@ -20,6 +20,13 @@ for chart in $CHARTS_DIRS; do
 		| yq -r 'select(.kind != "CustomResourceDefinition") | .. | .image?' \
 		| grep -v "null" \
 		| grep -v "^---$" > $TMP_IMAGE_FILE
+
+	# For admission-controller, also extract PolicyServer image from ConfigMap
+	if [[ $chart == */admission-controller ]]; then
+		helm template --values "$chart"/values.yaml --set recommendedPolicies.enabled=true "$chart"/ \
+			| yq -r 'select(.kind=="ConfigMap") | .data[] | select(. != null) | from_yaml | select(.kind=="PolicyServer") | .spec.image' >> $TMP_IMAGE_FILE
+	fi
+
 	mv $TMP_IMAGE_FILE "$chart"/$IMAGELIST_FILENAME
 done
 

--- a/scripts/extract_images.sh
+++ b/scripts/extract_images.sh
@@ -15,9 +15,12 @@ for chart in $CHARTS_DIRS; do
 	# the set CLI flag is used only by the controller chart. But to
 	# simplify the script, it will be passed for all the chart. It will be
 	# ignore for the other chart anyway
-	helm template --values "$chart"/values.yaml --set auditScanner.policyReporter=true "$chart"/ | yq -r "..|.image?" | grep -v "null"  > $TMP_IMAGE_FILE
-	sed --in-place '/---/d' $TMP_IMAGE_FILE
-	mv $TMP_IMAGE_FILE "$chart"/$IMAGELIST_FILENAME 
+	# Filter out CRDs to avoid capturing schema fields named "image"
+	helm template --values "$chart"/values.yaml --set auditScanner.policyReporter=true "$chart"/ \
+		| yq -r 'select(.kind != "CustomResourceDefinition") | .. | .image?' \
+		| grep -v "null" \
+		| grep -v "^---$" > $TMP_IMAGE_FILE
+	mv $TMP_IMAGE_FILE "$chart"/$IMAGELIST_FILENAME
 done
 
 # Delete the empty imagelist.txt files.

--- a/scripts/extract_policies.sh
+++ b/scripts/extract_policies.sh
@@ -12,10 +12,11 @@ if [ -e $POLICYLIST_FILENAME ]; then
 fi
 
 for chart in $CHARTS_DIRS; do
-	if [[ $chart == *"-defaults" ]]; then
+	if [[ $chart == */admission-controller ]]; then
+		# For admission-controller, policies are embedded in ConfigMap data as strings
+		# We need to extract them differently than top-level policy resources
 		helm template --values "$chart"/values.yaml --set recommendedPolicies.enabled=true "$chart/" \
-			| yq -r ". | select(.kind==\"ClusterAdmissionPolicy\" or .kind==\"AdmissionPolicy\") | .spec.module" > "$TMP_POLICY_FILE"
-		sed --in-place '/---/d' $TMP_POLICY_FILE
+			| yq -r '. | select(.kind=="ConfigMap") | .data[] | select(. != null) | from_yaml | select(.kind=="ClusterAdmissionPolicy" or .kind=="AdmissionPolicy") | .spec.module' > "$TMP_POLICY_FILE"
 		# adds the registry prefix if necessary
 		file=$(cat $TMP_POLICY_FILE)
 		for line in $file; do

--- a/scripts/extract_policies.sh
+++ b/scripts/extract_policies.sh
@@ -2,37 +2,29 @@
 set -euo pipefail
 
 CHART_DIR="$1"
-CHARTS_DIRS=$(find "$CHART_DIR" -type d -exec test -e '{}'/values.yaml \; -print | grep -v -E "kubewarden-(crds|controller|defaults)")
+ADMISSION_CONTROLLER_CHART="$CHART_DIR/admission-controller"
 POLICYLIST_FILENAME=policylist.txt
 TMP_POLICY_FILE=/tmp/$POLICYLIST_FILENAME
 
+# Clean up any existing policy list files
 find "$CHART_DIR" -type f -name $POLICYLIST_FILENAME -delete
-if [ -e $POLICYLIST_FILENAME ]; then
-       rm $POLICYLIST_FILENAME
-fi
+[ -e $POLICYLIST_FILENAME ] && rm $POLICYLIST_FILENAME
 
-for chart in $CHARTS_DIRS; do
-	if [[ $chart == */admission-controller ]]; then
-		# For admission-controller, policies are embedded in ConfigMap data as strings
-		# We need to extract them differently than top-level policy resources
-		helm template --values "$chart"/values.yaml --set recommendedPolicies.enabled=true "$chart/" \
-			| yq -r '. | select(.kind=="ConfigMap") | .data[] | select(. != null) | from_yaml | select(.kind=="ClusterAdmissionPolicy" or .kind=="AdmissionPolicy") | .spec.module' > "$TMP_POLICY_FILE"
-		# adds the registry prefix if necessary
-		file=$(cat $TMP_POLICY_FILE)
-		for line in $file; do
-			if [[ $(echo "$line" | awk '!/(https:\/\/|registry:\/\/)/') ]]; then
-				echo "$line" | sed 's/^/registry:\/\//'  >> "$chart"/$POLICYLIST_FILENAME 
-				continue
-			fi
-			echo "$line" >> "$chart"/$POLICYLIST_FILENAME 
-		done
+# Extract policies from admission-controller chart
+helm template --values "$ADMISSION_CONTROLLER_CHART"/values.yaml --set recommendedPolicies.enabled=true "$ADMISSION_CONTROLLER_CHART/" \
+	| yq -r '. | select(.kind=="ConfigMap") | .data[] | select(. != null) | from_yaml | select(.kind=="ClusterAdmissionPolicy" or .kind=="AdmissionPolicy") | .spec.module' > "$TMP_POLICY_FILE"
+
+# Add registry prefix if necessary and write to chart's policylist.txt
+while IFS= read -r line; do
+	if [[ $(echo "$line" | awk '!/(https:\/\/|registry:\/\/)/') ]]; then
+		echo "$line" | sed 's/^/registry:\/\//' >> "$ADMISSION_CONTROLLER_CHART"/$POLICYLIST_FILENAME
+	else
+		echo "$line" >> "$ADMISSION_CONTROLLER_CHART"/$POLICYLIST_FILENAME
 	fi
-done
+done < "$TMP_POLICY_FILE"
 
-# Delete the empty policylist.txt files.
-find "$CHART_DIR" -type f -name $POLICYLIST_FILENAME -empty -delete
-find "$CHART_DIR" -type f -name $POLICYLIST_FILENAME -print0 | xargs --null cat > $TMP_POLICY_FILE
-mv $TMP_POLICY_FILE $POLICYLIST_FILENAME
-# Sort policylist file
-find "$CHART_DIR" -type f -name $POLICYLIST_FILENAME -exec sort -u -o \{\} \{\} \;
-sort -u -o $POLICYLIST_FILENAME $POLICYLIST_FILENAME
+# Sort the chart's policylist.txt
+sort -u -o "$ADMISSION_CONTROLLER_CHART"/$POLICYLIST_FILENAME "$ADMISSION_CONTROLLER_CHART"/$POLICYLIST_FILENAME
+
+# Create master policylist.txt at root
+cp "$ADMISSION_CONTROLLER_CHART"/$POLICYLIST_FILENAME $POLICYLIST_FILENAME


### PR DESCRIPTION
## Description

Several fixes in the script used to generate the images and policy list files embedded in the helm chart tarballs to facilitate the airgap installations. 

> [!WARNING]
> I'm aware of some discussions to deprecate these files. But so far, they are still supported. Therefore, I've already fix them to the next release