### PR TITLE
chore: add deprecated legacy charts warning

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -1,10 +1,30 @@
 # Kubewarden helm-charts
 
-Kubewarden is a Kubernetes Dynamic Admission Controller that uses policies written
-in WebAssembly.
+Welcome to the Kubewarden project.
 
-You can combine all values from all charts on a single `values.yaml` file.
+The Kubewarden project comprises two components: Admission Controller and SBOMScanner.
 
-_**Note:**_ [`kubewarden-crds`](./kubewarden-crds) is the Helm chart that installs the Custom Resources Definition required by the Kubewarden stack. It should be installed before installing [`kubewarden-controller`](./kubewarden-controller) and [`kubewarden-defaults`](./kubewarden-defaults) charts.
+The Kubewarden Admission Controller is a Kubernetes Dynamic Admission Controller
+that uses policies written in WebAssembly.
+
+SBOMScanner is a SBOM-centric security scanner for Kubernetes. It can scan container
+registries, container images running inside of your cluster and even the nodes of
+your Kubernetes cluster.
+
+## Charts
+
+- [`admission-controller`](./admission-controller): the chart installing the
+  Kubewarden Admission Controller.
+- [`sbomscanner`](./sbomscanner): the chart installing SBOMscanner.
+
+### Deprecated charts
+
+The Kubewarden Admission Controller used to be installed through three separate
+charts, which are now deprecated in favor of the unified
+[`admission-controller`](./admission-controller) chart:
+
+- [`kubewarden-crds`](./kubewarden-crds)
+- [`kubewarden-controller`](./kubewarden-controller)
+- [`kubewarden-defaults`](./kubewarden-defaults)
 
 For more information refer to the [official Kubewarden website](https://kubewarden.io/).

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.14.0
+version: 5.14.1
 # This is the version of Kubewarden stack
 appVersion: v1.36.0
 annotations:

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -26,6 +26,7 @@ maintainers:
 version: 5.14.1
 # This is the version of Kubewarden stack
 appVersion: v1.36.0
+deprecated: true
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
@@ -45,6 +46,10 @@ annotations:
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool
+  catalog.cattle.io/deprecated: "true"
+  artifacthub.io/changes: |
+    - kind: deprecated
+      description: This Helm chart is deprecated in favor of the admission-controller
 dependencies:
   - name: policy-reporter
     version: 3.7.4

--- a/charts/kubewarden-controller/Chart.yaml
+++ b/charts/kubewarden-controller/Chart.yaml
@@ -36,7 +36,7 @@ annotations:
   catalog.cattle.io/display-name: Kubewarden # Only for Charts with custom UI
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
-  catalog.cattle.io/auto-install: kubewarden-crds=1.28.0
+  catalog.cattle.io/auto-install: kubewarden-crds=1.28.1
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
   # The following two will create a UI warning if the request is not available in cluster
   # Assume the most standard setup for your chart. These can be strings with amounts, ie 64Mi or 2Gi are both valid.

--- a/charts/kubewarden-controller/README.md
+++ b/charts/kubewarden-controller/README.md
@@ -1,3 +1,9 @@
+> [!WARNING] 
+> **This chart is deprecated.** The `kubewarden-crds`, `kubewarden-controller`,
+> and `kubewarden-defaults` charts have been superseded by the unified
+> [`admission-controller`](https://artifacthub.io/packages/helm/kubewarden/admission-controller) chart. Please migrate to it —
+> see the [migration guide](https://docs.kubewarden.io/admission-controller/1.37/en/howtos/chart-migration).
+
 [![Kubewarden Core Repository](https://github.com/kubewarden/community/blob/main/badges/kubewarden-core.svg)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#core-scope)
 [![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)
 [![Artifact HUB](https://img.shields.io/badge/ArtifactHub-Helm_Charts-blue?style=flat&logo=artifacthub&link=https%3A%2F%2Fartifacthub.io%2Fpackages%2Fsearch%3Frepo%3Dkubewarden%26kind%3D0%26verified_publisher%3Dtrue%26official%3Dtrue%26cncf%3Dtrue%26sort%3Drelevance%26page%3D1)](https://artifacthub.io/packages/search?repo=kubewarden&kind=0&verified_publisher=true&official=true&cncf=true&sort=relevance&page=1)

--- a/charts/kubewarden-controller/README.md
+++ b/charts/kubewarden-controller/README.md
@@ -2,7 +2,7 @@
 > **This chart is deprecated.** The `kubewarden-crds`, `kubewarden-controller`,
 > and `kubewarden-defaults` charts have been superseded by the unified
 > [`admission-controller`](https://artifacthub.io/packages/helm/kubewarden/admission-controller) chart. Please migrate to it —
-> see the [migration guide](https://docs.kubewarden.io/admission-controller/1.37/en/howtos/chart-migration).
+> see the [migration guide](https://docs.kubewarden.io/admission-controller/1.37/en/community-specific/howtos/migration/app136-to-app137-migration.html).
 
 [![Kubewarden Core Repository](https://github.com/kubewarden/community/blob/main/badges/kubewarden-core.svg)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#core-scope)
 [![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -25,6 +25,7 @@ keywords:
 version: 1.28.1
 # This is the version of Kubewarden stack
 appVersion: v1.36.0
+deprecated: true
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
@@ -36,6 +37,10 @@ annotations:
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool
+  catalog.cattle.io/deprecated: "true"
+  artifacthub.io/changes: |
+    - kind: deprecated
+      description: This Helm chart is deprecated in favor of the admission-controller
 dependencies:
   - name: openreports
     version: 0.2.1

--- a/charts/kubewarden-crds/Chart.yaml
+++ b/charts/kubewarden-crds/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.28.0
+version: 1.28.1
 # This is the version of Kubewarden stack
 appVersion: v1.36.0
 annotations:

--- a/charts/kubewarden-crds/README.md
+++ b/charts/kubewarden-crds/README.md
@@ -1,3 +1,9 @@
+> [!WARNING] 
+> **This chart is deprecated.** The `kubewarden-crds`, `kubewarden-controller`,
+> and `kubewarden-defaults` charts have been superseded by the unified
+> [`admission-controller`](https://artifacthub.io/packages/helm/kubewarden/admission-controller) chart. Please migrate to it —
+> see the [migration guide](https://docs.kubewarden.io/admission-controller/1.37/en/howtos/chart-migration).
+
 # kubewarden-crds
 
 `kubewarden-crds` is the Helm chart that installs the Custom Resources Definition
@@ -7,17 +13,17 @@ required by the Kubewarden stack. It should be installed before installing
 ## Contents
 
 This chart installs Kubewarden CRDs:
-  `admissionpolicies.policies.kubewarden.io`
-  `clusteradmissionpolicies.policies.kubewarden.io`
-  `policyservers.policies.kubewarden.io`
+`admissionpolicies.policies.kubewarden.io`
+`clusteradmissionpolicies.policies.kubewarden.io`
+`policyservers.policies.kubewarden.io`
 
 And OpenReport CRDs:
-  `reports.openreports.io`
-  `clusterreports.openreports.io`
+`reports.openreports.io`
+`clusterreports.openreports.io`
 
 It also installs PolicyReports CRDs (marked as deprecated):
-  `policyreports.wgpolicyk8s.io`
-  `clusterpolicyreports.wgpolicyk8s.io`
+`policyreports.wgpolicyk8s.io`
+`clusterpolicyreports.wgpolicyk8s.io`
 
 You can skip installing these (maybe because for example they are already installed
 and owned by a different Helm Release), by configuring the appropriate chart values.
@@ -25,6 +31,7 @@ and owned by a different Helm Release), by configuring the appropriate chart val
 ## Installing
 
 For example:
+
 ```console
 $ helm repo add kubewarden https://charts.kubewarden.io
 $ helm install --create-namespace -n kubewarden kubewarden-crds kubewarden/kubewarden-crds

--- a/charts/kubewarden-crds/README.md
+++ b/charts/kubewarden-crds/README.md
@@ -2,7 +2,7 @@
 > **This chart is deprecated.** The `kubewarden-crds`, `kubewarden-controller`,
 > and `kubewarden-defaults` charts have been superseded by the unified
 > [`admission-controller`](https://artifacthub.io/packages/helm/kubewarden/admission-controller) chart. Please migrate to it —
-> see the [migration guide](https://docs.kubewarden.io/admission-controller/1.37/en/howtos/chart-migration).
+> see the [migration guide](https://docs.kubewarden.io/admission-controller/1.37/en/community-specific/howtos/migration/app136-to-app137-migration.html).
 
 # kubewarden-crds
 

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -25,6 +25,7 @@ keywords:
 version: 3.14.1
 # This is the version of Kubewarden stack
 appVersion: v1.36.0
+deprecated: true
 annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
@@ -39,3 +40,7 @@ annotations:
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool
+  catalog.cattle.io/deprecated: "true"
+  artifacthub.io/changes: |
+    - kind: deprecated
+      description: This Helm chart is deprecated in favor of the admission-controller

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.14.0
+version: 3.14.1
 # This is the version of Kubewarden stack
 appVersion: v1.36.0
 annotations:

--- a/charts/kubewarden-defaults/Chart.yaml
+++ b/charts/kubewarden-defaults/Chart.yaml
@@ -36,7 +36,7 @@ annotations:
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
   catalog.cattle.io/hidden: "true" # Hide specific charts. Only use on CRD charts.
-  catalog.cattle.io/auto-install: kubewarden-crds=1.28.0
+  catalog.cattle.io/auto-install: kubewarden-crds=1.28.1
   # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
   # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
   catalog.cattle.io/type: cluster-tool

--- a/charts/kubewarden-defaults/README.md
+++ b/charts/kubewarden-defaults/README.md
@@ -1,21 +1,26 @@
+> [!WARNING] 
+> **This chart is deprecated.** The `kubewarden-crds`, `kubewarden-controller`,
+> and `kubewarden-defaults` charts have been superseded by the unified
+> [`admission-controller`](https://artifacthub.io/packages/helm/kubewarden/admission-controller) chart. Please migrate to it —
+> see the [migration guide](https://docs.kubewarden.io/admission-controller/1.37/en/howtos/chart-migration).
+
 # kubewarden-defaults
 
 `kubewarden-defaults` is the Helm chart that installs a default PolicyServer
-required by the Kubewarden to run `ClusterAdmissionPolicy` and  `AdmissionPolicy`. It should be installed
+required by the Kubewarden to run `ClusterAdmissionPolicy` and `AdmissionPolicy`. It should be installed
 before installing any policies.
-
 
 ## Enable recommended policies
 
 The chart allows the user to install some recommended policies to enforce some
-best practice security checks. ***By the default, the policies are disabled and the
-user must enable this feature.*** The recommended policies are:
+best practice security checks. **_By the default, the policies are disabled and the
+user must enable this feature._** The recommended policies are:
 
 - [`allow-privilege-escalation-psp` policy](https://github.com/kubewarden/allow-privilege-escalation-psp-policy): prevents process to gain more privileges.
 - [`host-namespaces-psp` policy](https://github.com/kubewarden/host-namespaces-psp-policy): blocks pods trying to share host's IPC, networks and PID namespaces
 - [`pod-privileged` policy](https://github.com/kubewarden/pod-privileged-policy): does not allow pod running in privileged mode
 - [`user-group-psp` policy](https://github.com/kubewarden/user-group-psp-policy): prevents pod running with root user
-- [`hostpaths-psp` policy](https://github.com/kubewarden/hostpaths-psp-policy): prevents containers from accessing host paths when  hosthPath volumes are defined
+- [`hostpaths-psp` policy](https://github.com/kubewarden/hostpaths-psp-policy): prevents containers from accessing host paths when hosthPath volumes are defined
 - [`capabilities-psp` policy](https://github.com/kubewarden/capabilities-psp-policy): prevents containers from adding Linux capabilities
 
 All the policies are installed cluster wide. But they are configured to ignore
@@ -50,10 +55,10 @@ Check out the configuration section to see all the configuration options.
 The user can also change the policies mode after the installation. See the
 Kubewarden documentation to learn more.
 
-
 ## Installing
 
 For example:
+
 ```console
 $ helm repo add kubewarden https://charts.kubewarden.io
 $ helm install --create-namespace -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults

--- a/charts/kubewarden-defaults/README.md
+++ b/charts/kubewarden-defaults/README.md
@@ -2,7 +2,7 @@
 > **This chart is deprecated.** The `kubewarden-crds`, `kubewarden-controller`,
 > and `kubewarden-defaults` charts have been superseded by the unified
 > [`admission-controller`](https://artifacthub.io/packages/helm/kubewarden/admission-controller) chart. Please migrate to it —
-> see the [migration guide](https://docs.kubewarden.io/admission-controller/1.37/en/howtos/chart-migration).
+> see the [migration guide](https://docs.kubewarden.io/admission-controller/1.37/en/community-specific/howtos/migration/app136-to-app137-migration.html).
 
 # kubewarden-defaults
 


### PR DESCRIPTION
> [!WARNING]
> This should not be merged until the unified helm chart (admission-controller) is released as GA. 

## Description

Updates Helm charts README files adding the deprecated warnings and updates the chart website index README to mention not only the new unified helm chart but also the SBOMScanner component helm chart.

Fix https://github.com/kubewarden/helm-charts/issues/1029
