### PR TITLE
Rename chart for Rancher

### DIFF
--- a/charts/admission-controller/Chart.yaml
+++ b/charts/admission-controller/Chart.yaml
@@ -30,9 +30,9 @@ annotations:
   # required ones:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
   catalog.cattle.io/namespace: cattle-kubewarden-system # Must prefix with cattle- and suffix with -system
-  catalog.cattle.io/release-name: rancher-kubewarden-controller # If this is an upstream app, prefixing with rancher is the preferred naming choice.
+  catalog.cattle.io/release-name: rancher-admission-controller # If this is an upstream app, prefixing with rancher is the preferred naming choice.
   catalog.cattle.io/ui-component: kubewarden # This is added for custom UI deployment of a chart
-  catalog.cattle.io/display-name: Kubewarden # Only for Charts with custom UI
+  catalog.cattle.io/display-name: Admission Controller # Only for Charts with custom UI
   catalog.cattle.io/os: linux # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
   # optional ones:
   catalog.cattle.io/provides-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.


### PR DESCRIPTION
## Description

Rename title of rancher chart to Admission Controller.

Also changing app name to match chart name.
If they don't match they are joined and final name is `rancher-kubewarden-controller-admission-controller`, which breaks length limit.