### PR TITLE
Fix airgap qcow2 image

### DIFF
--- a/.github/workflows/e2e-airgap.yml
+++ b/.github/workflows/e2e-airgap.yml
@@ -86,7 +86,7 @@ jobs:
         id: download_qcow2
         run: |
           QCOW2_FILE="rancher-image.qcow2"
-          gcloud storage cp gs://elemental-airgap-image/${QCOW2_FILE} ${HOME}/${QCOW2_FILE}
+          gcloud storage cp gs://airgap-image/${QCOW2_FILE} ${HOME}/${QCOW2_FILE}
 
       - name: Setup Go
         id: setup_go


### PR DESCRIPTION
Someone deleted our qcow2 image used by elemental and kubewarden test.
I created a new image based on Leap 16 and I changed the name to be more generic.

## Verification run
https://github.com/kubewarden/helm-charts/actions/runs/29426037928 ✅ 
