### PR TITLE
Use lightweight runner template for e2e workflows

### DIFF
--- a/.github/workflows/e2e-airgap-upgrade.yml
+++ b/.github/workflows/e2e-airgap-upgrade.yml
@@ -25,7 +25,7 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: kubewarden-e2e-ci-runner-x86-64-template-v1
+        default: kubewarden-e2e-ci-runner-x86-64-template-light-v2
         type: string
       zone:
         description: GCP zone to host the runner

--- a/.github/workflows/e2e-airgap.yml
+++ b/.github/workflows/e2e-airgap.yml
@@ -25,7 +25,7 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: kubewarden-e2e-ci-runner-x86-64-template-v1
+        default: kubewarden-e2e-ci-runner-x86-64-template-light-v2
         type: string
       zone:
         description: GCP zone to host the runner

--- a/.github/workflows/e2e-backup-restore.yml
+++ b/.github/workflows/e2e-backup-restore.yml
@@ -13,7 +13,7 @@ on:
         default: 'v1.34.7+k3s1'
       runner_template:
         description: Runner template to use
-        default: kubewarden-e2e-ci-runner-x86-64-template-v1
+        default: kubewarden-e2e-ci-runner-x86-64-template-light-v2
         type: string
       zone:
         description: GCP zone to host the runner


### PR DESCRIPTION
## Description

In recent days, we had some issues when creating VMs in GCP due to ressource availability so I decided to create a lightweight template with less CPU, memory and disk. It will also cost less money.
CI tests are still green with the new template.

<img width="1627" height="772" alt="image" src="https://github.com/user-attachments/assets/6538b7bf-542e-497e-966b-ba9586a130ef" />
