### PR TITLE
Fix airgap upgrade for single helm chart

### DIFF
--- a/.github/workflows/e2e-airgap-upgrade.yml
+++ b/.github/workflows/e2e-airgap-upgrade.yml
@@ -111,8 +111,8 @@ jobs:
         working-directory: ./e2e-tests
         run: |
           helm repo add kubewarden https://charts.kubewarden.io
-          DEFAULTS_CHART_VERSION=$(VERSION=prev ./scripts/helmer.sh versions | awk 'match($0, /defaults:([^ )]+)/, a) { print a[1] }')
-          RELEASE_BASE="https://github.com/kubewarden/helm-charts/releases/download/kubewarden-defaults-${DEFAULTS_CHART_VERSION}"
+          DEFAULTS_CHART_VERSION=$(VERSION=prev ./scripts/helmer.sh versions | awk 'match($0, /controller:([^ )]+)/, a) { print a[1] }')
+          RELEASE_BASE="https://github.com/kubewarden/helm-charts/releases/download/admission-controller-${DEFAULTS_CHART_VERSION}"
           wget "${RELEASE_BASE}/hauler_manifest.yaml" -O ../charts/hauler_manifest_prev.yaml
           wget "${RELEASE_BASE}/hauler_manifest_cosign.bundle" -O ../charts/hauler_manifest_prev.cosign.bundle
           cosign verify-blob \


### PR DESCRIPTION
Fix #1039 

Now we have the single helm chart release and next version available, we can modify the upgrade test to work with it.

I already [changed the upgrade instructions](https://github.com/kubewarden/kubewarden-end-to-end-tests/pull/319/changes#diff-26d6c19d24042ba88194c44eb0607a879c0bbffd30a57496b9e64fe9079bfac6) so the only change is how we can gather the correct previous version.

## Verification run
https://github.com/kubewarden/helm-charts/actions/runs/33020206716 ✅ 

<details><summary>Hauler file for installation</summary>
<p>

```
# This is a base file to be used to import all the required resources to run
# Kubewarden in airgap environment into Hauler.
#
# To sync this file with Hauler and load everything into its storage, you can
# run:
# hauler store sync --filename hauler_manifest.yaml
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: kubewarden-container-images
  annotations:
    hauler.dev/certificate-oidc-issuer: https://token.actions.githubusercontent.com
spec:
  images:
    - name: ghcr.io/kubewarden/adm-controller/audit-scanner:v1.37.1
      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.1
    - name: ghcr.io/kubewarden/adm-controller/controller:v1.37.1
      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.1
    - name: ghcr.io/kubewarden/adm-controller/policy-server:v1.37.1
      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.1
---
# The policies are in a separated definition just to allow a better keyless validation
# without the need to duplicate configuration
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: kubewarden-policies
  annotations:
    hauler.dev/certificate-oidc-issuer: https://token.actions.githubusercontent.com
    hauler.dev/certificate-identity-regexp: https://github.com/kubewarden/policies/.github/workflows/release.yml@refs/tags/.*
spec:
  images:
    - name: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v1.0.12
    - name: ghcr.io/kubewarden/policies/capabilities-psp:v1.0.12
    - name: ghcr.io/kubewarden/policies/host-namespaces-psp:v1.1.10
    - name: ghcr.io/kubewarden/policies/hostpaths-psp:v1.1.9
    - name: ghcr.io/kubewarden/policies/pod-privileged:v1.0.12
    - name: ghcr.io/kubewarden/policies/user-group-psp:v1.1.5
---
# The policy reporter and kuberlr images are defined in the dedicated manifest section because
# the container images are not signed. Therefore, this difference is very clear
# to future readers.
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: kubewarden-not-signed-images
spec:
  images:
    - name: ghcr.io/kyverno/policy-reporter-ui:2.7.0
    - name: ghcr.io/kyverno/policy-reporter:3.9.0
    - name: ghcr.io/rancher/kuberlr-kubectl:v8.1.1
---
apiVersion: content.hauler.cattle.io/v1
kind: Charts
metadata:
  name: kubewarden-helm-charts
spec:
  charts:
    - name: admission-controller
      repoURL: https://charts.kubewarden.io
      version: 6.0.1
    - name: policy-reporter
      version: 3.9.1
      repoURL: https://kyverno.github.io/policy-reporter
    - name: openreports
      version: 0.2.1
      repoURL: https://openreports.github.io/reports-api

```
</p>
</details> 



<details><summary>Hauler file for upgrade</summary>
<p>

```
# This is a base file to be used to import all the required resources to run
# Kubewarden in airgap environment into Hauler.
#
# To sync this file with Hauler and load everything into its storage, you can
# run:
# hauler store sync --filename hauler_manifest.yaml
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: kubewarden-container-images
  annotations:
    hauler.dev/certificate-oidc-issuer: https://token.actions.githubusercontent.com
spec:
  images:
    - name: ghcr.io/kubewarden/adm-controller/audit-scanner:v1.37.2
      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.2
    - name: ghcr.io/kubewarden/adm-controller/controller:v1.37.2
      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.2
    - name: ghcr.io/kubewarden/adm-controller/policy-server:v1.37.2
      certificate-identity-regexp: https://github.com/kubewarden/adm-controller/.github/workflows/release.yml@refs/tags/v1.37.2
---
# The policies are in a separated definition just to allow a better keyless validation
# without the need to duplicate configuration
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: kubewarden-policies
  annotations:
    hauler.dev/certificate-oidc-issuer: https://token.actions.githubusercontent.com
    hauler.dev/certificate-identity-regexp: https://github.com/kubewarden/policies/.github/workflows/release.yml@refs/tags/.*
spec:
  images:
    - name: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v1.0.13
    - name: ghcr.io/kubewarden/policies/capabilities-psp:v1.0.13
    - name: ghcr.io/kubewarden/policies/host-namespaces-psp:v1.1.11
    - name: ghcr.io/kubewarden/policies/hostpaths-psp:v1.1.10
    - name: ghcr.io/kubewarden/policies/pod-privileged:v1.0.13
    - name: ghcr.io/kubewarden/policies/user-group-psp:v1.1.5
---
# The policy reporter and kuberlr images are defined in the dedicated manifest section because
# the container images are not signed. Therefore, this difference is very clear
# to future readers.
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: kubewarden-not-signed-images
spec:
  images:
    - name: ghcr.io/kyverno/policy-reporter-ui:2.7.0
    - name: ghcr.io/kyverno/policy-reporter:3.9.0
    - name: ghcr.io/rancher/kuberlr-kubectl:v8.1.1
---
apiVersion: content.hauler.cattle.io/v1
kind: Charts
metadata:
  name: kubewarden-helm-charts
spec:
  charts:
    - name: admission-controller
      repoURL: https://charts.kubewarden.io
      version: 6.0.2
    - name: policy-reporter
      version: 3.9.1
      repoURL: https://kyverno.github.io/policy-reporter
    - name: openreports
      version: 0.2.1
      repoURL: https://openreports.github.io/reports-api
```

</p>
</details> 