### PR TITLE
Fix links in charts/README for gh-pages

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -13,18 +13,18 @@ your Kubernetes cluster.
 
 ## Charts
 
-- [`admission-controller`](./admission-controller): the chart installing the
+- [`admission-controller`](https://github.com/kubewarden/helm-charts/tree/main/charts/admission-controller): the chart installing the
   Kubewarden Admission Controller.
-- [`sbomscanner`](./sbomscanner): the chart installing SBOMscanner.
+- [`sbomscanner`](https://github.com/kubewarden/helm-charts/tree/main/charts/sbomscanner): the chart installing SBOMscanner.
 
 ### Deprecated charts
 
 The Kubewarden Admission Controller used to be installed through three separate
 charts, which are now deprecated in favor of the unified
-[`admission-controller`](./admission-controller) chart:
+[`admission-controller`](https://github.com/kubewarden/helm-charts/tree/main/charts/admission-controller) chart:
 
-- [`kubewarden-crds`](./kubewarden-crds)
-- [`kubewarden-controller`](./kubewarden-controller)
-- [`kubewarden-defaults`](./kubewarden-defaults)
+- [`kubewarden-crds`](https://github.com/kubewarden/helm-charts/tree/main/charts/kubewarden-crds)
+- [`kubewarden-controller`](https://github.com/kubewarden/helm-charts/tree/main/charts/kubewarden-controller)
+- [`kubewarden-defaults`](https://github.com/kubewarden/helm-charts/tree/main/charts/kubewarden-defaults)
 
 For more information refer to the [official Kubewarden website](https://kubewarden.io/).


### PR DESCRIPTION
## Description

The readme contains relative links which are broken on the gh-pages branch and consequently on charts.kubewarden.io

Fixes #806 

## Test

Try clicking the links on charts.kubewarden.io and in the readme from https://github.com/dcermak/helm-charts/blob/patch-1/charts/README.md

## Additional Information

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
