### PR TITLE
feat(ci): add network-enforcer chart sync and release automation

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -251,3 +251,11 @@ jobs:
           push-to-registry: true
           subject-name: ${{ env.REGISTRY}}/admission-controller
           subject-digest: ${{ env.DIGEST_admission-controller }}
+
+      - name: Generate provenance attestation for network-enforcer chart and push to OCI
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        if: env.DIGEST_network-enforcer != ''
+        with:
+          push-to-registry: true
+          subject-name: ${{ env.REGISTRY}}/network-enforcer
+          subject-digest: ${{ env.DIGEST_network-enforcer }}

--- a/.github/workflows/update-network-enforcer.yaml
+++ b/.github/workflows/update-network-enforcer.yaml
@@ -1,0 +1,36 @@
+name: Sync network-enforcer Helm chart
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch of the network-enforcer repository to sync the Helm chart from"
+        required: false
+        default: "main"
+  repository_dispatch:
+    types: [release-network-enforcer]
+
+jobs:
+  sync-network-enforcer:
+    name: Sync network-enforcer Helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@41b9c8d707830a9daebaeaa84c1b62d60b779564 # v3.6.0
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Update network-enforcer helm chart
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+          NETWORK_ENFORCER_BRANCH: ${{ inputs.branch || 'main' }}
+        run: |-
+          updatecli compose apply --file ./updatecli/network-enforcer-release.yaml

--- a/updatecli/network-enforcer-release.yaml
+++ b/updatecli/network-enforcer-release.yaml
@@ -1,0 +1,6 @@
+policies:
+  - name: sync network-enforcer Helm chart
+    config:
+      - ./updatecli.d/network_enforcer_chart_sync.yaml
+    values:
+      - ./values.yaml

--- a/updatecli/updatecli.d/network_enforcer_chart_sync.yaml
+++ b/updatecli/updatecli.d/network_enforcer_chart_sync.yaml
@@ -1,0 +1,120 @@
+# This Updatecli policy is only compatible for UNIX system
+# And designed to be call such as
+# ```
+# updatecli apply --config updatecli/updatecli.d/network_enforcer_chart_sync.yaml --values updatecli/values.yaml
+# ```
+
+name: sync network-enforcer helm chart
+pipelineid: network_enforcer_release
+
+targets:
+  default:
+    name: "chore: sync network-enforcer helm chart"
+    kind: shell
+    scmid: default
+    disablesourceinput: true
+    spec:
+      changedif:
+        kind: exitcode
+        spec:
+          success: 0
+          failure: 1
+          warning: 2
+      command: |
+        set -e
+
+        # Custom exit code used by Updatecli to understand
+        # how to handle the script output
+        # Exit 1 if something went wrong
+        # Exit 2 if the script changed chart files
+        # Exit 0 if nothing changed at the end of the script
+
+        CHART_NAME="network-enforcer"
+        GIT_REPO="https://github.com/kubewarden/network-enforcer.git"
+
+        # Branch of the network-enforcer repository to sync the chart from,
+        # falls back to main when the environment variable is not set
+        GIT_BRANCH="{{ env (index . "network-enforcer").branch }}"
+        GIT_BRANCH="${GIT_BRANCH:-main}"
+
+        # The GIT_DIR is an arbritary directory that use
+        # to temporary git clone the network-enforcer git repository
+        GIT_DIR="/tmp/updatecli/tmp/network-enforcer"
+
+        GIT_DIR_SUB_PATH="charts/$CHART_NAME"
+
+        ## Remove any existing directory
+        ## to start from a fresh environment
+        if [ -d "$GIT_DIR" ]; then
+          rm -Rf "$GIT_DIR"
+        fi
+
+        ## Only clone the Helm chart directory that we need to sync
+        git clone --depth 1 --filter=blob:none --branch "$GIT_BRANCH" "$GIT_REPO" --sparse "$GIT_DIR"
+
+        CURRENT_DIR=$PWD
+        cd "$GIT_DIR" || exit 1
+        git sparse-checkout set "$GIT_DIR_SUB_PATH"
+        cd "$CURRENT_DIR" || exit 1
+
+        BEFORE_CHECKSUM=""
+
+        CURRENT_DIR=$PWD
+        cd "$GIT_DIR" || exit 1
+        AFTER_CHECKSUM=$(find $GIT_DIR_SUB_PATH   -type f -exec sha256sum {} \;)
+        cd "$CURRENT_DIR" || exit 1
+
+
+        if [ -d "charts/$CHART_NAME" ]; then
+          BEFORE_CHECKSUM=$(find charts/$CHART_NAME -type f -exec sha256sum {} \;)
+        fi
+
+        # To keep Updatecli idempotent, we only change the files
+        # if we are not in dry run mode
+        # DRY_RUN is an environment variable set by Updatecli
+        # depending if we execute `updatecli apply` or `updatecli diff`
+        if [ "$DRY_RUN" = "false" ]; then
+          rm -rf "charts/$CHART_NAME"
+          cp -R "$GIT_DIR/$GIT_DIR_SUB_PATH" charts/
+          AFTER_CHECKSUM=$(find charts/$CHART_NAME   -type f -exec sha256sum {} \;)
+        fi
+
+        if [ "$BEFORE_CHECKSUM" = "$AFTER_CHECKSUM" ]; then
+          exit 0
+        fi
+
+        exit 2
+
+actions:
+  createUpdatePR:
+    title: "network-enforcer helm chart update"
+    kind: "github/pullrequest"
+    scmid: "default"
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic Helm chart update.
+        This PR has been created by the automation used to automatically update the network-enforcer
+        Helm chart from The https://github.com/kubewarden/network-enforcer.git
+      draft: false
+      labels:
+        - "dependencies"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "helm-charts"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ .github.branch }}"
+      commitmessage:
+        type: "chore(deps)"
+        title: "Update network-enforcer Helm chart"
+        hidecredit: true
+        footers: "Signed-off-by: {{ .github.author }} <{{ .github.email }}>"
+        squash: true

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -10,4 +10,6 @@ github:
   user: "UPDATECLI_GITHUB_OWNER"
 sbomscanner:
   branch: "SBOMSCANNER_BRANCH"
+network-enforcer:
+  branch: "NETWORK_ENFORCER_BRANCH"
 


### PR DESCRIPTION
## Description
Syncing the chart for network-enforcer on every release :+1: 

At the moment this PR also requires to drop `--no-additional-values` when generating the helm values schema. We have to either decide to do that or implement Fixes https://github.com/kubewarden/network-enforcer/issues/420 limiting the injection of new values to the admission controller as well.

Fixes https://github.com/kubewarden/network-enforcer/issues/415

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:

```shell
   POLICY=updatecli/updatecli.d/network_enforcer_chart_sync.yaml
   awk '/^actions:/{exit} {print}' "$POLICY" | grep -v '^    scmid: default$' > /tmp/m.yaml

   updatecli apply --config /tmp/m.yaml --values updatecli/values.yaml   # -> Changed: 1
   updatecli apply --config /tmp/m.yaml --values updatecli/values.yaml   # -> Succeeded: 1, Changed: 0
```

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [X] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
