### PR TITLE
fix(scripts): only pass auditScanner flag to the admission-controller chart

### DIFF
--- a/scripts/extract_images.sh
+++ b/scripts/extract_images.sh
@@ -12,11 +12,18 @@ if [ -e $IMAGELIST_FILENAME ]; then
 fi
 
 for chart in $CHARTS_DIRS; do
-	# the set CLI flag is used only by the controller chart. But to
-	# simplify the script, it will be passed for all the chart. It will be
-	# ignore for the other chart anyway
+	# The auditScanner.policyReporter flag is only meaningful for the
+	# admission-controller chart, so only pass it there. It must not be
+	# passed to every chart: a chart whose values.schema.json sets
+	# `additionalProperties: false` rejects unknown keys, which makes
+	# `helm template` fail instead of silently ignoring the flag.
+	helm_template_args=(--values "$chart"/values.yaml)
+	if [[ $chart == */admission-controller ]]; then
+		helm_template_args+=(--set auditScanner.policyReporter=true)
+	fi
+
 	# Filter out CRDs to avoid capturing schema fields named "image"
-	helm template --values "$chart"/values.yaml --set auditScanner.policyReporter=true "$chart"/ \
+	helm template "${helm_template_args[@]}" "$chart"/ \
 		| yq -r 'select(.kind != "CustomResourceDefinition") | .. | .image?' \
 		| grep -v "null" \
 		| grep -v "^---$" > $TMP_IMAGE_FILE


### PR DESCRIPTION


## Description
Passing `auditScanner` flag only to admission-controller chart :+1: 

Fixes https://github.com/kubewarden/network-enforcer/issues/420

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [X] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
