### PR TITLE
feat(ci): add runtime-enforcer chart sync and release

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -259,3 +259,11 @@ jobs:
           push-to-registry: true
           subject-name: ${{ env.REGISTRY}}/network-enforcer
           subject-digest: ${{ env.DIGEST_network-enforcer }}
+
+      - name: Generate provenance attestation for runtime-enforcer chart and push to OCI
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        if: env.DIGEST_runtime-enforcer != ''
+        with:
+          push-to-registry: true
+          subject-name: ${{ env.REGISTRY}}/runtime-enforcer
+          subject-digest: ${{ env.DIGEST_runtime-enforcer }}

--- a/.github/workflows/update-runtime-enforcer.yaml
+++ b/.github/workflows/update-runtime-enforcer.yaml
@@ -1,0 +1,36 @@
+name: Sync runtime-enforcer Helm chart
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch of the runtime-enforcer repository to sync the Helm chart from"
+        required: false
+        default: "main"
+  repository_dispatch:
+    types: [release-runtime-enforcer]
+
+jobs:
+  sync-runtime-enforcer:
+    name: Sync runtime-enforcer Helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@41b9c8d707830a9daebaeaa84c1b62d60b779564 # v3.6.0
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Update runtime-enforcer helm chart
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+          RUNTIME_ENFORCER_BRANCH: ${{ inputs.branch || 'main' }}
+        run: |-
+          updatecli compose apply --file ./updatecli/runtime-enforcer-release.yaml

--- a/updatecli/runtime-enforcer-release.yaml
+++ b/updatecli/runtime-enforcer-release.yaml
@@ -1,0 +1,6 @@
+policies:
+  - name: sync runtime-enforcer Helm chart
+    config:
+      - ./updatecli.d/runtime_enforcer_chart_sync.yaml
+    values:
+      - ./values.yaml

--- a/updatecli/updatecli.d/runtime_enforcer_chart_sync.yaml
+++ b/updatecli/updatecli.d/runtime_enforcer_chart_sync.yaml
@@ -1,0 +1,120 @@
+# This Updatecli policy is only compatible for UNIX system
+# And designed to be call such as
+# ```
+# updatecli apply --config updatecli/updatecli.d/runtime_enforcer_chart_sync.yaml --values updatecli/values.yaml
+# ```
+
+name: sync runtime-enforcer helm chart
+pipelineid: runtime_enforcer_release
+
+targets:
+  default:
+    name: "chore: sync runtime-enforcer helm chart"
+    kind: shell
+    scmid: default
+    disablesourceinput: true
+    spec:
+      changedif:
+        kind: exitcode
+        spec:
+          success: 0
+          failure: 1
+          warning: 2
+      command: |
+        set -e
+
+        # Custom exit code used by Updatecli to understand
+        # how to handle the script output
+        # Exit 1 if something went wrong
+        # Exit 2 if the script changed chart files
+        # Exit 0 if nothing changed at the end of the script
+
+        CHART_NAME="runtime-enforcer"
+        GIT_REPO="https://github.com/kubewarden/runtime-enforcer.git"
+
+        # Branch of the runtime-enforcer repository to sync the chart from,
+        # falls back to main when the environment variable is not set
+        GIT_BRANCH="{{ env (index . "runtime-enforcer").branch }}"
+        GIT_BRANCH="${GIT_BRANCH:-main}"
+
+        # The GIT_DIR is an arbritary directory that use
+        # to temporary git clone the runtime-enforcer git repository
+        GIT_DIR="/tmp/updatecli/tmp/runtime-enforcer"
+
+        GIT_DIR_SUB_PATH="charts/$CHART_NAME"
+
+        ## Remove any existing directory
+        ## to start from a fresh environment
+        if [ -d "$GIT_DIR" ]; then
+          rm -Rf "$GIT_DIR"
+        fi
+
+        ## Only clone the Helm chart directory that we need to sync
+        git clone --depth 1 --filter=blob:none --branch "$GIT_BRANCH" "$GIT_REPO" --sparse "$GIT_DIR"
+
+        CURRENT_DIR=$PWD
+        cd "$GIT_DIR" || exit 1
+        git sparse-checkout set "$GIT_DIR_SUB_PATH"
+        cd "$CURRENT_DIR" || exit 1
+
+        BEFORE_CHECKSUM=""
+
+        CURRENT_DIR=$PWD
+        cd "$GIT_DIR" || exit 1
+        AFTER_CHECKSUM=$(find $GIT_DIR_SUB_PATH   -type f -exec sha256sum {} \;)
+        cd "$CURRENT_DIR" || exit 1
+
+
+        if [ -d "charts/$CHART_NAME" ]; then
+          BEFORE_CHECKSUM=$(find charts/$CHART_NAME -type f -exec sha256sum {} \;)
+        fi
+
+        # To keep Updatecli idempotent, we only change the files
+        # if we are not in dry run mode
+        # DRY_RUN is an environment variable set by Updatecli
+        # depending if we execute `updatecli apply` or `updatecli diff`
+        if [ "$DRY_RUN" = "false" ]; then
+          rm -rf "charts/$CHART_NAME"
+          cp -R "$GIT_DIR/$GIT_DIR_SUB_PATH" charts/
+          AFTER_CHECKSUM=$(find charts/$CHART_NAME   -type f -exec sha256sum {} \;)
+        fi
+
+        if [ "$BEFORE_CHECKSUM" = "$AFTER_CHECKSUM" ]; then
+          exit 0
+        fi
+
+        exit 2
+
+actions:
+  createUpdatePR:
+    title: "runtime-enforcer helm chart update"
+    kind: "github/pullrequest"
+    scmid: "default"
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic Helm chart update.
+        This PR has been created by the automation used to automatically update the runtime-enforcer
+        Helm chart from The https://github.com/kubewarden/runtime-enforcer.git
+      draft: false
+      labels:
+        - "dependencies"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "helm-charts"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ .github.branch }}"
+      commitmessage:
+        type: "chore(deps)"
+        title: "Update runtime-enforcer Helm chart"
+        hidecredit: true
+        footers: "Signed-off-by: {{ .github.author }} <{{ .github.email }}>"
+        squash: true

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -12,4 +12,6 @@ sbomscanner:
   branch: "SBOMSCANNER_BRANCH"
 network-enforcer:
   branch: "NETWORK_ENFORCER_BRANCH"
+runtime-enforcer:
+  branch: "RUNTIME_ENFORCER_BRANCH"
 


### PR DESCRIPTION
## Description

This PR mirrors what https://github.com/kubewarden/helm-charts/pull/1058 does in order to implement chart sync logic for runtime-enforcer.

The updatecli PR: https://github.com/holyspectral/helm-charts/pull/1

Fix https://github.com/kubewarden/runtime-enforcer/issues/894

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:

```shell
# Run the below command with UPDATECLI_GITHUB_OWNER and UPDATECLI_GITHUB_TOKEN pointing to your fork:
updatecli apply --config updatecli/updatecli.d/runtime_enforcer_chart_sync.yaml --values updatecli/values.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [x] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
